### PR TITLE
Fix network change error on place bid button

### DIFF
--- a/apps/web/src/components/Auction/Settle.tsx
+++ b/apps/web/src/components/Auction/Settle.tsx
@@ -18,10 +18,7 @@ export const Settle = ({ isEnding }: SettleProps) => {
   const [settling, setSettling] = useState(false)
 
   const handleSettle = React.useCallback(async () => {
-    const isWrongNetwork =
-      (await signer?.provider?.getCode(auctionContract?.address || '')) === '0x'
-
-    if (!auctionContract || !signer || isWrongNetwork) return
+    if (!auctionContract || !signer) return
 
     setSettling(true)
     try {

--- a/apps/web/src/components/Layout/NavMenu.tsx
+++ b/apps/web/src/components/Layout/NavMenu.tsx
@@ -221,14 +221,14 @@ const NavMenu: React.FC<{}> = () => {
             >
               <Link href={'/explore'}>
                 <Flex display="flex" align="center" justify={'center'} py={'x2'}>
-                  <Text cursor={'pointer'} fontWeight={'display'} lineHeight={24}>
+                  <Text cursor={'pointer'} fontWeight={'display'}>
                     Explore
                   </Text>
                 </Flex>
               </Link>
               <Link href={'/about'}>
                 <Flex display="flex" align="center" justify={'center'} py={'x2'}>
-                  <Text cursor={'pointer'} fontWeight={'display'} lineHeight={24}>
+                  <Text cursor={'pointer'} fontWeight={'display'}>
                     About
                   </Text>
                 </Flex>


### PR DESCRIPTION
## Problem

We get an underlying network change error when switching to the wrong designated network. 

## Solution

Use wagmi's useBalance hook to fetch the balance for the user instead of fetching it off of the signer's provider, which throws an unhandled and uncaught error on switching networks.

## Risks

Current functionality should remain the same.

## Code review

Any notes for code reviewing peers?

## Testing

What is the procedure for testing this change?

- [x] Have you tested it yourself?
- [ ] Unit tests
