### PR TITLE
Clean up zustand deprecated warnings

### DIFF
--- a/apps/web/src/stores/useFormStore.tsx
+++ b/apps/web/src/stores/useFormStore.tsx
@@ -10,10 +10,9 @@ import {
   votingSettingsProps,
 } from 'src/typings'
 import { create } from 'zustand'
-import { persist } from 'zustand/middleware'
+import { createJSONStorage, persist } from 'zustand/middleware'
 import { PUBLIC_BUILDER_ADDRESS, PUBLIC_NOUNS_ADDRESS } from 'src/constants/addresses'
 import { yearsAhead } from 'src/utils/helpers'
-import { ethers } from 'ethers'
 
 export interface FormStoreState {
   activeSection: number
@@ -210,7 +209,7 @@ export const useFormStore = create(
     }),
     {
       name: `nouns-builder-create-${process.env.NEXT_PUBLIC_CHAIN_ID}`,
-      getStorage: () => localStorage,
+      storage: createJSONStorage(() => localStorage),
       version: 0,
     }
   )


### PR DESCRIPTION
## Problem

Zustand was giving console warnings for using deprecated fields.

## Solution

Replace deprecated `getStorage` field with `storage` in `persist` callback

## Risks

Are there open questions, risks or edge cases to watch for?

## Code review

Any notes for code reviewing peers?

## Testing

What is the procedure for testing this change?

- [ ] Have you tested it yourself?
- [ ] Unit tests
