### PR TITLE
Return access denied on proposal create pages for users without correct permissions

### DIFF
--- a/apps/web/src/hooks/useVotes.ts
+++ b/apps/web/src/hooks/useVotes.ts
@@ -31,6 +31,7 @@ export const useVotes = ({
 
   if (!data || isLoading || data.some(isNil)) {
     return {
+      isLoading,
       isOwner: false,
       hasThreshold: false,
     }
@@ -39,6 +40,7 @@ export const useVotes = ({
   const [votes, proposalThreshold] = data
 
   return {
+    isLoading,
     isOwner: votes.toNumber() > proposalThreshold.toNumber(),
     hasThreshold: votes.toNumber() > 0,
   }

--- a/apps/web/src/pages/dao/[token]/proposal/create.tsx
+++ b/apps/web/src/pages/dao/[token]/proposal/create.tsx
@@ -4,7 +4,7 @@ import TwoColumnLayout from 'src/layouts/TwoColumn'
 import Entry from 'src/modules/transaction-builder/components/Entry/Entry'
 import { Queue } from 'src/modules/transaction-builder/components/Queue/Queue'
 import CreateProposalHeading from 'src/modules/transaction-builder/components/CreateProposalHeading'
-import { Stack } from '@zoralabs/zord'
+import { Flex, Stack } from '@zoralabs/zord'
 import { NextPageWithLayout } from 'src/pages/_app'
 import { getDaoLayout } from 'src/layouts/DaoLayout/DaoLayout'
 import {
@@ -14,11 +14,25 @@ import {
 import TransactionTypeIcon from 'src/modules/transaction-builder/components/TransactionTypeIcon'
 import DropdownSelect from 'src/modules/transaction-builder/components/DropdownSelect'
 import { SelectedTransactionForm } from 'src/modules/transaction-builder/components/SelectedTransactionForm'
+import { useVotes } from 'src/hooks/useVotes'
+import { useDaoStore } from 'src/stores'
+import { useAccount } from 'wagmi'
+import { AddressType } from 'src/typings'
+import { notFoundWrap } from 'src/styles/404.css'
 
 const CreateProposalPage: NextPageWithLayout = () => {
   const router = useRouter()
   const { query, pathname } = router
   const { transaction } = query
+
+  const { addresses } = useDaoStore()
+  const { address } = useAccount()
+
+  const { isLoading, hasThreshold } = useVotes({
+    governorAddress: addresses?.governor,
+    signerAddress: address,
+    collectionAddress: query?.token as AddressType,
+  })
 
   const createSelectOption = (type: TransactionType) => ({
     value: type,
@@ -35,6 +49,12 @@ const CreateProposalPage: NextPageWithLayout = () => {
       pathname,
       query: { token: query.token, transaction: value },
     })
+  }
+
+  if (isLoading) return null
+
+  if (!hasThreshold) {
+    return <Flex className={notFoundWrap}>403 - Access Denied</Flex>
   }
 
   return (

--- a/apps/web/src/pages/dao/[token]/proposal/review.tsx
+++ b/apps/web/src/pages/dao/[token]/proposal/review.tsx
@@ -1,17 +1,40 @@
 import React from 'react'
 import CreateProposalHeading from 'src/modules/transaction-builder/components/CreateProposalHeading'
-import { Stack } from '@zoralabs/zord'
+import { Flex, Stack } from '@zoralabs/zord'
 import { ReviewProposalForm } from 'src/modules/transaction-builder'
 import { useProposalStore } from 'src/modules/transaction-builder/stores/useProposalStore'
 import { getDaoLayout } from 'src/layouts/DaoLayout/DaoLayout'
 import { NextPageWithLayout } from 'src/pages/_app'
 import { useRouter } from 'next/router'
+import { useVotes } from 'src/hooks/useVotes'
+import { useDaoStore } from 'src/stores'
+import { AddressType } from 'src/typings'
+import { useAccount } from 'wagmi'
+import { notFoundWrap } from 'src/styles/404.css'
 
 const ReviewProposalPage: NextPageWithLayout = () => {
+  const router = useRouter()
+  const { query } = router
+
+  const { addresses } = useDaoStore()
+  const { address } = useAccount()
+
+  const { isLoading, hasThreshold } = useVotes({
+    governorAddress: addresses?.governor,
+    signerAddress: address,
+    collectionAddress: query?.token as AddressType,
+  })
+
   const transactions = useProposalStore((state) => state.transactions)
   const disabled = useProposalStore((state) => state.disabled)
   const title = useProposalStore((state) => state.title)
   const summary = useProposalStore((state) => state.summary)
+
+  if (isLoading) return null
+
+  if (!hasThreshold) {
+    return <Flex className={notFoundWrap}>403 - Access Denied</Flex>
+  }
 
   return (
     <Stack mb={'x20'} w={'100%'} px={'x3'} style={{ maxWidth: 1060 }} mx="auto">


### PR DESCRIPTION
## Problem

User can access proposal create pages for daos they are not members of

## Solution

Show "Access Denied" screen if a user is not a member of a dao
<img width="1091" alt="Screenshot 2023-02-20 at 19 27 23" src="https://user-images.githubusercontent.com/119885280/220178126-55b5ff67-53a2-4351-b92b-aa79aa712885.png">

## Risks

Are there open questions, risks or edge cases to watch for?

## Code review

Any notes for code reviewing peers?

## Testing

What is the procedure for testing this change?

- [x] Have you tested it yourself?
- [ ] Unit tests
