### PR TITLE
Use prepare contract write hook to settle auction

### DIFF
--- a/apps/web/src/components/Auction/Settle.tsx
+++ b/apps/web/src/components/Auction/Settle.tsx
@@ -27,7 +27,7 @@ export const Settle = ({ isEnding }: SettleProps) => {
 
   const [settling, setSettling] = useState(false)
 
-  const handleSettle = React.useCallback(async () => {
+  const handleSettle = async () => {
     if (!signer) return
 
     if (!!error) return
@@ -40,7 +40,7 @@ export const Settle = ({ isEnding }: SettleProps) => {
     } catch (error) {
       setSettling(false)
     }
-  }, [signer])
+  }
 
   if (isEnding && !settling) {
     return (


### PR DESCRIPTION
## Problem

@isaaczaak reported some issues settling an auction on mobile.

## Solution

re-factor to use [wagmi's prepare transaction](https://wagmi.sh/react/prepare-hooks) hook better handling on mobile

## Risks

settling an auction should work as is

## Code review

please test this out on both mobile and desktop!

## Testing

What is the procedure for testing this change?

- [ ] Have you tested it yourself?
- [ ] Unit tests
