### PR TITLE
hotfix/ Sanitize Trait name in Artwork Upload

### DIFF
--- a/apps/web/src/modules/create/components/Artwork/ArtworkUpload.tsx
+++ b/apps/web/src/modules/create/components/Artwork/ArtworkUpload.tsx
@@ -89,7 +89,6 @@ export const ArtworkUpload: React.FC<ArtworkFormProps> = ({
           cid: upload?.ipfs?.cid || '',
           uri: upload?.ipfs?.uri || '',
           url: encodeURI(
-            //// maybe
             getFetchableUrl(upload?.ipfs?.uri) +
               `/${upload.webkitRelativePath.split('/').slice(1).join('/')}` || ''
           ),


### PR DESCRIPTION
## Problem

In refactoring of Artwork, we lost `sanitizeFileName` on the trait property, causing folder names with Caps to prevent our preview of the stacked artwork from properly working.

## Solution

Sanitize the trait name.

## Risks

Are there open questions, risks or edge cases to watch for?

Shouldn't be any restoring previous functionality

## Code review

Any notes for code reviewing peers?

## Testing

What is the procedure for testing this change?

Previews of artwork uploaded where there are caps in the folder name should still generate a proper preview.

- [x] Have you tested it yourself?
- [ ] Unit tests
