### PR TITLE
hotfix: sanitize file name on upload to ipfs

### DIFF
--- a/apps/web/src/modules/create-dao/components/Artwork/ArtworkUpload.tsx
+++ b/apps/web/src/modules/create-dao/components/Artwork/ArtworkUpload.tsx
@@ -129,7 +129,6 @@ export const ArtworkUpload: React.FC<ArtworkFormProps> = ({
 
     setIsProcessing(true)
     const filesArray = Array.from(files).filter((file) => file.name !== '.DS_Store')
-    // const acceptableMIME = ['image/jpeg', 'image/png', 'image/svg+xml', 'image/webp']
     const acceptableMIME = ['image/png', 'image/svg+xml']
 
     let collectionName: string = ''
@@ -288,7 +287,7 @@ export const ArtworkUpload: React.FC<ArtworkFormProps> = ({
     const ipfsUploadResponse = await uploadDirectory(
       files.map((file) => ({
         content: file,
-        path: file.webkitRelativePath.split('/').slice(1).join('/'),
+        path: sanitizeFileName(file.webkitRelativePath.split('/').slice(1).join('/')),
       })),
       { cache: false }
     )


### PR DESCRIPTION
## Problem

In refactoring the IPFS upload, I missed sanitizing **both** the file path on upload to `ipfs` and the file path name used in the Preview -- in yesterday's hotfix I resolved this issue only for Preview, without also resolving for the path used in the ipfs upload.

## Solution

1. `sanitizeFileName(path)` on upload to ipfs 

## Risks

Are there open questions, risks or edge cases to watch for?

## Code review

Any notes for code reviewing peers?

## Testing

What is the procedure for testing this change?

Deployed dao that triggered this issue (folder names with different case and symbols, file names with spaces) with successful display of artwork

https://testnet.nouns.build/dao/0xe9d375ee49581fc7953d66d6beeefa8e97b3490c/3

- [x] Have you tested it yourself?
- [ ] Unit tests
