### PR TITLE
Fix - label of custom transaction

### DIFF
--- a/apps/web/src/modules/create-proposal/constants/transactionType.tsx
+++ b/apps/web/src/modules/create-proposal/constants/transactionType.tsx
@@ -39,7 +39,7 @@ export const TRANSACTION_TYPES = {
     iconBackdrop: color.ghostHover,
   },
   [TransactionType.CUSTOM]: {
-    title: 'Custom Proposal',
+    title: 'Custom Transaction',
     subTitle: 'Create any other kind of transaction',
     icon: 'plus',
     iconBackdrop: color.ghostHover,


### PR DESCRIPTION
## Problem

Custom Transaction shortcut was labelled Custom Proposal

## Solution

Relabel to `Custom Transaction` 

## Risks

Are there open questions, risks or edge cases to watch for?

## Code review

Any notes for code reviewing peers?

## Testing

What is the procedure for testing this change?

- [x] Have you tested it yourself?
- [ ] Unit tests
