### PR TITLE
Re-factor dao deployment contract transaction

### DIFF
--- a/apps/web/src/modules/create-dao/components/ReviewAndDeploy/ReviewAndDeploy.tsx
+++ b/apps/web/src/modules/create-dao/components/ReviewAndDeploy/ReviewAndDeploy.tsx
@@ -1,7 +1,6 @@
 import {
   WriteContractUnpreparedArgs,
   prepareWriteContract,
-  waitForTransaction,
   writeContract,
 } from '@wagmi/core'
 import { Box, Button, Flex, atoms } from '@zoralabs/zord'
@@ -151,8 +150,8 @@ export const ReviewAndDeploy: React.FC<ReviewAndDeploy> = ({ title }) => {
         signer: signer,
         args: [founderParams, tokenParams, auctionParams, govParams],
       })
-      const { hash } = await writeContract(config)
-      transaction = await waitForTransaction({ hash })
+      const { wait } = await writeContract(config)
+      transaction = await wait()
     } catch (e) {
       setIsPendingTransaction(false)
       return


### PR DESCRIPTION
## Problem

We were listening on any DAODeployed event, which meant that any dao deployment would have been caught by the listener, changing screens for the user even if that wasn't their dao that they might have deployed with.

## Solution

Parse the events logs returned by a transaction receipt from the deployment contract transaction. Use this returned data for the deployed dao data.

## Risks

DAO deployments should work as is

## Code review

DAO deployments should work as is

## Testing

We should test this preview branch with simultaneous DAO deployments.

- [ ] Have you tested it yourself?
- [ ] Unit tests
