### PR TITLE
fix votes and threshold / resolve NOT_ENOUGH_VOTES error

### DIFF
--- a/apps/web/src/modules/create-proposal/components/ReviewProposalForm/ReviewProposalForm.tsx
+++ b/apps/web/src/modules/create-proposal/components/ReviewProposalForm/ReviewProposalForm.tsx
@@ -38,7 +38,7 @@ export const ReviewProposalForm = ({
   const { data: signer } = useSigner()
   const addresses = useDaoStore((state) => state.addresses)
   //@ts-ignore
-  const signerAddress = signer._address
+  const signerAddress = signer?._address
   const { clearProposal } = useProposalStore()
 
   const [error, setError] = useState<string | undefined>()


### PR DESCRIPTION
## Problem

Our use of `useGovernorContract` for `proposalThreshold` and `signerAddress` from `useLayoutStore` are causing problems on the `ReviewProposalForm`. When either was `undefined` `votes <= proposalThreshold` caused the `NOT_ENOUGH_VOTES` error to trigger

## Solution

Use wagmi's `useContractRead` and `useSigner` in order to get the `proposalThreshold` and `getVotes` of the signer. 

## Risks

Are there open questions, risks or edge cases to watch for?

## Code review

Any notes for code reviewing peers?

## Testing

What is the procedure for testing this change?

Attempt submitting a proposal from a dao you own tokens of 

- [x] Have you tested it yourself?
- [ ] Unit tests
