### PR TITLE
Separate update minters transaction type

### DIFF
--- a/apps/web/src/modules/create-proposal/components/Queue/Queue.tsx
+++ b/apps/web/src/modules/create-proposal/components/Queue/Queue.tsx
@@ -54,7 +54,10 @@ export const Queue: React.FC<QueueProps> = ({ setQueueModalOpen }) => {
               <TransactionCard
                 key={`${transaction.type}-${i}`}
                 handleRemove={() => confirmRemoveTransaction(i)}
-                disabled={transaction.type === TransactionType.UPGRADE}
+                disabled={
+                  transaction.type === TransactionType.UPGRADE ||
+                  transaction.type === TransactionType.UPDATE_MINTER
+                }
                 transaction={transaction}
               />
             ))

--- a/apps/web/src/modules/create-proposal/components/SelectTransactionType/SelectTransactionType.tsx
+++ b/apps/web/src/modules/create-proposal/components/SelectTransactionType/SelectTransactionType.tsx
@@ -1,15 +1,14 @@
 import { Flex, Stack, Text } from '@zoralabs/zord'
 import React from 'react'
 
-import { TransactionType } from 'src/modules/create-proposal'
-
+import { TRANSACTION_FORM_OPTIONS, TransactionFormType } from '../TransactionForm'
 import AdminNav from './AdminNav'
 import { NounsConnect } from './NounsConnect'
 import TransactionTypeCard from './TransactionTypeCard'
 
 interface SelectTransactionTypeProps {
-  transactionTypes: TransactionType[]
-  onSelect: (value: TransactionType) => void
+  transactionTypes: typeof TRANSACTION_FORM_OPTIONS
+  onSelect: (value: TransactionFormType) => void
 }
 
 export const SelectTransactionType: React.FC<SelectTransactionTypeProps> = ({

--- a/apps/web/src/modules/create-proposal/components/TransactionForm/Airdrop/Airdrop.tsx
+++ b/apps/web/src/modules/create-proposal/components/TransactionForm/Airdrop/Airdrop.tsx
@@ -107,10 +107,25 @@ export const Airdrop: React.FC = () => {
 
     const unit = amount > 1 ? 'tokens' : 'token'
 
+    const doesNotContainUpdateMinter =
+      transactions.findIndex(
+        (transaction) => transaction.type === TransactionType.UPDATE_MINTER
+      ) === -1
+
+    if (!isMinter && doesNotContainUpdateMinter) {
+      addTransaction({
+        type: TransactionType.UPDATE_MINTER,
+        summary: `Update minters with treasury address ${walletSnippet(
+          addresses?.treasury
+        )}`,
+        transactions: [updateMinterTransaction],
+      })
+    }
+
     addTransaction({
       type: TransactionType.AIRDROP,
       summary: `Airdrop ${amount} ${unit} to ${walletSnippet(recipient)}`,
-      transactions: [...(!isMinter ? [updateMinterTransaction] : []), airdropTransaction],
+      transactions: [airdropTransaction],
     })
 
     actions.resetForm()

--- a/apps/web/src/modules/create-proposal/components/TransactionForm/Airdrop/Airdrop.tsx
+++ b/apps/web/src/modules/create-proposal/components/TransactionForm/Airdrop/Airdrop.tsx
@@ -115,9 +115,7 @@ export const Airdrop: React.FC = () => {
     if (!isMinter && doesNotContainUpdateMinter) {
       addTransaction({
         type: TransactionType.UPDATE_MINTER,
-        summary: `Update minters with treasury address ${walletSnippet(
-          addresses?.treasury
-        )}`,
+        summary: `Updateminters to set the DAO treasury as sender`,
         transactions: [updateMinterTransaction],
       })
     }

--- a/apps/web/src/modules/create-proposal/components/TransactionForm/TransactionForm.tsx
+++ b/apps/web/src/modules/create-proposal/components/TransactionForm/TransactionForm.tsx
@@ -7,12 +7,10 @@ import { CustomTransaction } from './CustomTransaction'
 import { PauseAuctions } from './PauseAuctions'
 import { SendEth } from './SendEth'
 
-type TransactionFormType = {
-  [key in TransactionType]: ReactNode
-}
+export type TransactionFormType = typeof TRANSACTION_FORM_OPTIONS[number]
 
 interface TransactionFormProps {
-  type: TransactionType
+  type: TransactionFormType
 }
 
 export const TRANSACTION_FORM_OPTIONS = [
@@ -20,15 +18,14 @@ export const TRANSACTION_FORM_OPTIONS = [
   TransactionType.AIRDROP,
   TransactionType.PAUSE_AUCTIONS,
   TransactionType.CUSTOM,
-]
+] as const
 
 export const TransactionForm = ({ type }: TransactionFormProps) => {
-  const FORMS: TransactionFormType = {
+  const FORMS: { [key in TransactionFormType]: ReactNode } = {
     [TransactionType.CUSTOM]: <CustomTransaction />,
     [TransactionType.AIRDROP]: <Airdrop />,
     [TransactionType.SEND_ETH]: <SendEth />,
     [TransactionType.PAUSE_AUCTIONS]: <PauseAuctions />,
-    [TransactionType.UPGRADE]: null,
   }
 
   return <>{FORMS[type]}</>

--- a/apps/web/src/modules/create-proposal/components/TransactionForm/TransactionForm.tsx
+++ b/apps/web/src/modules/create-proposal/components/TransactionForm/TransactionForm.tsx
@@ -7,11 +7,11 @@ import { CustomTransaction } from './CustomTransaction'
 import { PauseAuctions } from './PauseAuctions'
 import { SendEth } from './SendEth'
 
-export type TransactionFormType = typeof TRANSACTION_FORM_OPTIONS[number]
-
 interface TransactionFormProps {
   type: TransactionFormType
 }
+
+export type TransactionFormType = typeof TRANSACTION_FORM_OPTIONS[number]
 
 export const TRANSACTION_FORM_OPTIONS = [
   TransactionType.SEND_ETH,

--- a/apps/web/src/modules/create-proposal/components/TransactionTypeIcon.tsx
+++ b/apps/web/src/modules/create-proposal/components/TransactionTypeIcon.tsx
@@ -1,4 +1,4 @@
-import { Flex } from '@zoralabs/zord'
+import { Flex, color } from '@zoralabs/zord'
 
 import { Icon } from 'src/components/Icon'
 
@@ -20,12 +20,18 @@ export const TransactionTypeIcon: React.FC<TransactionTypeIconProps> = ({
       h={large ? 'x13' : 'x10'}
       w={large ? 'x13' : 'x10'}
       borderRadius={'round'}
-      style={{ backgroundColor: TRANSACTION_TYPES[transactionType].iconBackdrop }}
+      style={{
+        backgroundColor:
+          TRANSACTION_TYPES[transactionType]?.iconBackdrop ?? color.ghostHover,
+      }}
       my={'x4'}
       minH={large ? 'x13' : 'x10'}
       minW={large ? 'x13' : 'x10'}
     >
-      <Icon id={TRANSACTION_TYPES[transactionType].icon} fill={'transparent'} />
+      <Icon
+        id={TRANSACTION_TYPES[transactionType]?.icon ?? 'plus'}
+        fill={'transparent'}
+      />
     </Flex>
   )
 }

--- a/apps/web/src/modules/create-proposal/constants/transactionType.tsx
+++ b/apps/web/src/modules/create-proposal/constants/transactionType.tsx
@@ -8,6 +8,7 @@ export enum TransactionType {
   CUSTOM = 'custom',
   UPGRADE = 'upgrade',
   PAUSE_AUCTIONS = 'pause-auctions',
+  UPDATE_MINTER = 'update-minter',
 }
 
 export interface TransactionTypeProps {

--- a/apps/web/src/pages/dao/[token]/proposal/create.tsx
+++ b/apps/web/src/pages/dao/[token]/proposal/create.tsx
@@ -15,7 +15,7 @@ import {
   TRANSACTION_FORM_OPTIONS,
   TRANSACTION_TYPES,
   TransactionForm,
-  TransactionType,
+  TransactionFormType,
   TransactionTypeIcon,
   TwoColumnLayout,
   useProposalStore,
@@ -28,7 +28,10 @@ import { AddressType } from 'src/typings'
 const CreateProposalPage: NextPageWithLayout = () => {
   const router = useRouter()
   const { query } = router
-  const [transactionType, setTransactionType] = useState<TransactionType | undefined>()
+  const collectionAddress = query?.token as AddressType
+  const [transactionType, setTransactionType] = useState<
+    TransactionFormType | undefined
+  >()
   const transactions = useProposalStore((state) => state.transactions)
 
   useEffect(() => {
@@ -46,7 +49,7 @@ const CreateProposalPage: NextPageWithLayout = () => {
     collectionAddress: query?.token as AddressType,
   })
 
-  const createSelectOption = (type: TransactionType) => ({
+  const createSelectOption = (type: TransactionFormType) => ({
     value: type,
     label: TRANSACTION_TYPES[type].title,
     icon: <TransactionTypeIcon transactionType={type} />,
@@ -54,7 +57,7 @@ const CreateProposalPage: NextPageWithLayout = () => {
 
   const options = TRANSACTION_FORM_OPTIONS.map(createSelectOption)
 
-  const handleDropdownOnChange = (value: TransactionType) => {
+  const handleDropdownOnChange = (value: TransactionFormType) => {
     setTransactionType(value)
   }
 

--- a/apps/web/src/pages/dao/[token]/proposal/create.tsx
+++ b/apps/web/src/pages/dao/[token]/proposal/create.tsx
@@ -28,7 +28,6 @@ import { AddressType } from 'src/typings'
 const CreateProposalPage: NextPageWithLayout = () => {
   const router = useRouter()
   const { query } = router
-  const collectionAddress = query?.token as AddressType
   const [transactionType, setTransactionType] = useState<
     TransactionFormType | undefined
   >()
@@ -36,7 +35,7 @@ const CreateProposalPage: NextPageWithLayout = () => {
 
   useEffect(() => {
     if (transactions.length && !transactionType) {
-      setTransactionType(transactions[0].type)
+      setTransactionType(transactions[0].type as TransactionFormType)
     }
   }, [transactions, transactionType, setTransactionType])
 


### PR DESCRIPTION
## Problem

We currently add updateMinters for each 'batch to' transaction, this turns out a bit lengthy for proposals (This happened on a recent airdrop proposal for the entropy dao) with a longer list of transactions.

As referenced here: https://nouns.build/dao/0x8983ec4b57dbebe8944af8d4f9d3adbafea5b9f1/vote/0x9b2610da3bbdee52076e52c6e1b3d17056fdf5b8d85d3bf0bd4bd33b2297c561

## Solution

We should only add once, and make it visible as an un-editable transaction (similar to upgrades) if the treasury address is not a minter and UPDATE_MINTER is not already added to the transaction queue.

## Risks

Are there open questions, risks or edge cases to watch for?

## Code review

Added a fall back to the Transaction Type icon (to particularly handle cases where we want a default value for).

## Testing

Create an airdrop for a dao where the minter is already updated as the treasury address (there should be no update minter transaction added)
Create an airdrop for a dao where the treasury is NOT already listed as a minter (the udpate minter transaction should be added automatically and uneditable).

- [ ] Have you tested it yourself?
- [ ] Unit tests
