### PR TITLE
Fix returning to edit proposal does not show queue

### DIFF
--- a/apps/web/src/pages/dao/[token]/proposal/create.tsx
+++ b/apps/web/src/pages/dao/[token]/proposal/create.tsx
@@ -1,6 +1,6 @@
 import { Flex, Stack } from '@zoralabs/zord'
 import { useRouter } from 'next/router'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useAccount } from 'wagmi'
 
 import { useVotes } from 'src/hooks'
@@ -16,6 +16,7 @@ import {
   TransactionType,
   TransactionTypeIcon,
   TwoColumnLayout,
+  useProposalStore,
 } from 'src/modules/create-proposal'
 import { useDaoStore } from 'src/modules/dao'
 import { NextPageWithLayout } from 'src/pages/_app'
@@ -26,6 +27,13 @@ const CreateProposalPage: NextPageWithLayout = () => {
   const router = useRouter()
   const { query } = router
   const [transactionType, setTransactionType] = useState<TransactionType | undefined>()
+  const transactions = useProposalStore((state) => state.transactions)
+
+  useEffect(() => {
+    if (transactions.length && !transactionType) {
+      setTransactionType(transactions[0].type)
+    }
+  }, [transactions, transactionType, setTransactionType])
 
   const { addresses } = useDaoStore()
   const { address } = useAccount()


### PR DESCRIPTION
## Description

<!--- Describe your changes. -->

On the proposal create page, if there are transactions in the proposal store, set the transactionType so that the Queue is rendered.

## Motivation & context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Code review

<!--- Any notes for code review? -->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have done a self-review of my own code
- [ ] Any new and existing tests pass locally with my changes
- [ ] My changes generate no new warnings (lint warnings, console warnings, etc)
