### PR TITLE
Fix check for token of a proposal

### DIFF
--- a/apps/web/src/pages/dao/[token]/vote/[id].tsx
+++ b/apps/web/src/pages/dao/[token]/vote/[id].tsx
@@ -129,8 +129,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     return {
       props: {
         fallback: {
-          [unstable_serialize([SWR_KEYS.PROPOSAL, proposal?.proposalId])]:
-            proposal,
+          [unstable_serialize([SWR_KEYS.PROPOSAL, proposal?.proposalId])]: proposal,
         },
         proposalId: id,
         token: tokenData,


### PR DESCRIPTION
## Description

Prevent proposals from DAOs that aren't associated with the DAO in the url from rendering.

## Motivation & context

This tweet accidentally linked `mferbuilderDAO` token address with a proposal from `builderDAO` -- the proposal still rendered even though the proposal does not exist on `mferbuilderDAO` DAO. 

https://twitter.com/isaaccyn/status/1631980727297515520?s=46&t=wDdxskMEJxdAkSQUOUArfA

This PR checks that the `proposal?.collectionAddress ===  token?.address` and if it doesn't returns a 404.

## Code review


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have done a self-review of my own code
- [x] Any new and existing tests pass locally with my changes
- [x] My changes generate no new warnings (lint warnings, console warnings, etc)
