### PR TITLE
Add tokenid to dao card navigation link

### DIFF
--- a/apps/web/src/modules/dao/components/DaoCard/DaoCard.tsx
+++ b/apps/web/src/modules/dao/components/DaoCard/DaoCard.tsx
@@ -16,6 +16,7 @@ import { Detail } from './Detail'
 interface DaoCardProps {
   collectionAddress: string
   tokenName?: string
+  tokenId?: string
   tokenImage?: string
   collectionName?: string
   bid?: BigNumberish
@@ -31,6 +32,7 @@ export const DaoCard = ({
   collectionAddress,
   tokenName,
   tokenImage,
+  tokenId,
   collectionName,
   bid,
   endTime,
@@ -48,7 +50,7 @@ export const DaoCard = ({
   const isOver = !!endTime ? dayjs.unix(Date.now() / 1000) >= dayjs.unix(endTime) : true
 
   return (
-    <Link href={`/dao/${collectionAddress}`}>
+    <Link href={`/dao/${collectionAddress}/${tokenId}`}>
       <Box borderRadius="curved" height={'100%'} overflow="hidden">
         <Box
           backgroundColor="background2"

--- a/apps/web/src/modules/dao/components/DaoCard/DaoCard.tsx
+++ b/apps/web/src/modules/dao/components/DaoCard/DaoCard.tsx
@@ -50,7 +50,7 @@ export const DaoCard = ({
   const isOver = !!endTime ? dayjs.unix(Date.now() / 1000) >= dayjs.unix(endTime) : true
 
   return (
-    <Link href={`/dao/${collectionAddress}/${tokenId}`}>
+    <Link href={`/dao/${collectionAddress}/${tokenId}`} prefetch={false}>
       <Box borderRadius="curved" height={'100%'} overflow="hidden">
         <Box
           backgroundColor="background2"

--- a/apps/web/src/modules/dao/components/DaoFeed/DaoFeedCard.tsx
+++ b/apps/web/src/modules/dao/components/DaoFeed/DaoFeedCard.tsx
@@ -10,7 +10,7 @@ interface DaoCardProps {
 }
 
 export const DaoFeedCard: React.FC<DaoCardProps> = ({ dao }) => {
-  const { highestBid, tokenUri, endTime } = useDaoFeedCard({
+  const { highestBid, tokenId, tokenUri, endTime } = useDaoFeedCard({
     collectionAddress: dao.collectionAddress,
     auctionAddress: dao.auctionAddress,
   })
@@ -23,6 +23,7 @@ export const DaoFeedCard: React.FC<DaoCardProps> = ({ dao }) => {
     <DaoCard
       tokenName={tokenUri?.name}
       tokenImage={tokenUri?.image}
+      tokenId={tokenId?.toString()}
       collectionName={dao?.name}
       collectionAddress={dao.collectionAddress}
       bid={highestBid}

--- a/apps/web/src/modules/dao/components/Explore/Explore.tsx
+++ b/apps/web/src/modules/dao/components/Explore/Explore.tsx
@@ -81,6 +81,7 @@ export const Explore: React.FC<ExploreProps> = ({ daos, pageInfo }) => {
           <Grid className={exploreGrid}>
             {daos?.map((dao) => (
               <DaoCard
+                tokenId={dao.tokenId ?? undefined}
                 key={dao.collectionAddress}
                 tokenImage={dao.image ?? undefined}
                 tokenName={dao.name ?? undefined}

--- a/apps/web/src/modules/dao/components/Explore/ExploreMyDaos.tsx
+++ b/apps/web/src/modules/dao/components/Explore/ExploreMyDaos.tsx
@@ -16,9 +16,11 @@ export const ExploreMyDaos = () => {
 
   const { data } = useSWR(
     signerAddress ? SWR_KEYS.DYNAMIC.MY_DAOS_PAGE(signerAddress as string) : null,
-    () => userDaosFilter('', signerAddress as string),
+    () => userDaosFilter(null, signerAddress as string),
     { revalidateOnFocus: false }
   )
+
+  if (!data) return null
 
   return (
     <>
@@ -27,6 +29,7 @@ export const ExploreMyDaos = () => {
         <Grid className={exploreGrid} mb={'x16'}>
           {data.daos.map((dao) => (
             <DaoCard
+              tokenId={dao.tokenId ?? undefined}
               key={dao.collectionAddress}
               tokenImage={dao.image ?? undefined}
               tokenName={dao.name ?? undefined}

--- a/apps/web/src/modules/dao/hooks/useDaoFeedCard.ts
+++ b/apps/web/src/modules/dao/hooks/useDaoFeedCard.ts
@@ -9,15 +9,6 @@ interface useDaoCardProps {
   auctionAddress: string
 }
 
-interface AuctionProps {
-  tokenId: BigNumber
-  highestBid: BigNumber
-  highestBidder: string
-  startTime: number
-  endTime: number
-  settled: boolean
-}
-
 export const useDaoFeedCard = ({
   collectionAddress,
   auctionAddress,
@@ -68,5 +59,6 @@ export const useDaoFeedCard = ({
       : undefined,
     tokenUri: decode(token),
     endTime: auction?.endTime || 0,
+    tokenId: auction?.tokenId,
   }
 }


### PR DESCRIPTION
## Description

In the return response we receive the token id of the current active auction. 

## Motivation & context

We should instead navigate directly to that given token id instead of to dao address to by-pass the re-direct.

## Code review

<!--- Any notes for code review? -->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have done a self-review of my own code
- [x] Any new and existing tests pass locally with my changes
- [x] My changes generate no new warnings (lint warnings, console warnings, etc)
