### PR TITLE
Handle undefined allocation percentage values

### DIFF
--- a/apps/web/src/modules/create-dao/components/ReviewAndDeploy/ReviewAndDeploy.tsx
+++ b/apps/web/src/modules/create-dao/components/ReviewAndDeploy/ReviewAndDeploy.tsx
@@ -47,6 +47,8 @@ const DEPLOYMENT_ERROR = {
     'Oops! It looks like you have no founders set. Please go back to the allocation step and add at least one founder address.',
   GENERIC:
     'Oops! Looks like there was a problem handling the dao deployment. Please ensure that input data from all the previous steps is correct',
+  INVALID_ALLOCATION_PERCENTAGE:
+    'Oops! Looks like there are undefined founder allocation values. Please go back to the allocation step to ensure that valid allocation values are set.',
 }
 
 export const ReviewAndDeploy: React.FC<ReviewAndDeploy> = ({ title }) => {
@@ -79,7 +81,7 @@ export const ReviewAndDeploy: React.FC<ReviewAndDeploy> = ({ title }) => {
     ...contributionAllocation,
   ].map(({ founderAddress, allocationPercentage: allocation, endDate }) => ({
     wallet: founderAddress as AddressType,
-    ownershipPct: BigNumber.from(allocation),
+    ownershipPct: allocation ? BigNumber.from(allocation) : BigNumber.from(0),
     vestExpiry: BigNumber.from(Math.floor(new Date(endDate).getTime() / 1000)),
   }))
 
@@ -129,6 +131,15 @@ export const ReviewAndDeploy: React.FC<ReviewAndDeploy> = ({ title }) => {
 
   const handleDeploy = async () => {
     setDeploymentError(undefined)
+
+    if (
+      [...founderAllocation, ...contributionAllocation].find(
+        (founder) => typeof founder.allocationPercentage === 'undefined'
+      )
+    ) {
+      setDeploymentError(DEPLOYMENT_ERROR.INVALID_ALLOCATION_PERCENTAGE)
+      return
+    }
 
     const signerAddress = await signer?.getAddress()
     if (founderParams[0].wallet !== signerAddress) {


### PR DESCRIPTION
## Description

We have validations on the allocation form that should in theory catch undefined values for an allocation percentage. Seems like some users are somehow skipping this step, which causes a client side error on the review & deploy step when attempting to convert to a bignumber from an undefined value 

## Motivation & context

Add more safeguards around determining whether or not there might be any undefined allocation percentages.

## Code review

Safely handle the bigNumber.from() given a defined value, and add a validation that prevents the user from proceeding if there happens to be an undefined allocation percentage.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have done a self-review of my own code
- [x] Any new and existing tests pass locally with my changes
- [x] My changes generate no new warnings (lint warnings, console warnings, etc)
