### PR TITLE
Add 'visit testnet / mainnet' to homepage

### DIFF
--- a/apps/web/src/components/Home/VisitAlternate.tsx
+++ b/apps/web/src/components/Home/VisitAlternate.tsx
@@ -1,0 +1,31 @@
+import { Flex, Text, atoms } from '@zoralabs/zord'
+
+import { useLayoutStore } from 'src/stores'
+
+import { Icon } from '../Icon'
+
+const VisitAlternate = () => {
+  const { isMobile } = useLayoutStore()
+  const isTestnet = process.env.NEXT_PUBLIC_CHAIN_ID === '5' ? true : false
+
+  return (
+    <a
+      href={isTestnet ? 'https://nouns.build/' : 'https://testnet.nouns.build/'}
+      target="_blank"
+      rel="noreferrer noopener"
+    >
+      <Flex align={'center'} mt={isMobile ? 'x3' : 'x6'} color="text1">
+        <Text
+          fontSize={isMobile ? 14 : 18}
+          fontWeight={'paragraph'}
+          className={atoms({ textDecoration: 'underline' })}
+        >
+          {isTestnet ? 'Visit Mainnet' : 'Visit Testnet'}
+        </Text>
+        <Icon fill="text1" size="sm" ml="x1" id="external-16" />
+      </Flex>
+    </a>
+  )
+}
+
+export default VisitAlternate

--- a/apps/web/src/pages/index.tsx
+++ b/apps/web/src/pages/index.tsx
@@ -8,6 +8,7 @@ import GetStarted from 'src/components/Home/GetStarted'
 import Marquee from 'src/components/Home/Marquee'
 import RecentlyCreated from 'src/components/Home/RecentlyCreated'
 import Twitter from 'src/components/Home/Twitter'
+import VisitAlternate from 'src/components/Home/VisitAlternate'
 import { Meta } from 'src/components/Meta'
 import { highestBidsRequest } from 'src/data/graphql/requests/homepageQuery'
 import { AuctionFragment } from 'src/data/graphql/sdk.generated'
@@ -32,6 +33,7 @@ const HomePage: NextPageWithLayout<{
       <Stack align={'center'}>
         <Marquee />
         <GetStarted />
+        <VisitAlternate />
         {featuredDaos && (
           <RecentlyCreated>
             <DaoFeed featuredDaos={featuredDaos} error={statusCode} />


### PR DESCRIPTION
## Description

Adds a link to visit testnet / mainnet on the homepage.

## Motivation & context

closes #143 

## Code review
- Ensure mainnet / testnet links show up properly depending on environment chainid
- Ensure mainnet / testnet links correctly link out to the right application
- Should `VisitAlternate` be renamed to something else?

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have done a self-review of my own code
- [x] Any new and existing tests pass locally with my changes
- [x] My changes generate no new warnings (lint warnings, console warnings, etc)
