### PR TITLE
Fix issue with long og descriptions

### DIFF
--- a/apps/web/src/pages/dao/[token]/[tokenId].tsx
+++ b/apps/web/src/pages/dao/[token]/[tokenId].tsx
@@ -93,6 +93,10 @@ const TokenPage: NextPageWithLayout<TokenPageProps> = ({
     return null
   }
 
+  const description = token.description ?? ''
+  const ogDescription =
+    description.length > 111 ? `${description.slice(0, 111)}...` : description
+
   return (
     <Flex direction="column" pb="x30">
       <Meta
@@ -100,7 +104,7 @@ const TokenPage: NextPageWithLayout<TokenPageProps> = ({
         type={`${collectionName}:nft`}
         image={ogImageURL}
         slug={url}
-        description={token.description ?? ''}
+        description={ogDescription}
       />
       <Auction auctionAddress={addresses.auction} collection={collection} token={token} />
       <SectionHandler


### PR DESCRIPTION
## Description

Long og descriptions would change formatting on certain platforms.

## Motivation & context

N/A

## Code review

- og metadata formats properly on all platforms

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have done a self-review of my own code
- [x] Any new and existing tests pass locally with my changes
- [x] My changes generate no new warnings (lint warnings, console warnings, etc)
