### PR TITLE
Fix issue with proposal og image rendering

### DIFF
--- a/apps/web/src/pages/api/og/proposal.tsx
+++ b/apps/web/src/pages/api/og/proposal.tsx
@@ -85,7 +85,10 @@ const ptRootBold = fetch(
 export type ProposalOgMetadata = {
   daoName: string
   daoImage: string
-  proposal: Proposal
+  proposal: Pick<
+    Proposal,
+    'proposalNumber' | 'title' | 'status' | 'forVotes' | 'againstVotes' | 'abstainVotes'
+  >
 }
 
 export default async function handler(req: NextRequest) {

--- a/apps/web/src/pages/dao/[token]/vote/[id].tsx
+++ b/apps/web/src/pages/dao/[token]/vote/[id].tsx
@@ -23,6 +23,7 @@ import {
   isProposalOpen,
 } from 'src/modules/proposal'
 import { NextPageWithLayout } from 'src/pages/_app'
+import { ProposalOgMetadata } from 'src/pages/api/og/proposal'
 import { propPageWrapper } from 'src/styles/Proposals.css'
 
 export interface VotePageProps {
@@ -140,16 +141,23 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
       }
     }
 
+    const ogMetadata: ProposalOgMetadata = {
+      proposal: {
+        proposalNumber: proposal.proposalNumber,
+        title: proposal.title,
+        status: proposal.status,
+        forVotes: proposal.forVotes,
+        againstVotes: proposal.againstVotes,
+        abstainVotes: proposal.abstainVotes,
+      },
+      daoName,
+      daoImage,
+    }
+
     const protocol = process.env.VERCEL_ENV === 'development' ? 'http' : 'https'
     const ogImageURL = `${protocol}://${
       context.req.headers.host
-    }/api/og/proposal?data=${encodeURIComponent(
-      JSON.stringify({
-        proposal,
-        daoName,
-        daoImage,
-      })
-    )}`
+    }/api/og/proposal?data=${encodeURIComponent(JSON.stringify(ogMetadata))}`
 
     return {
       props: {


### PR DESCRIPTION
## Description

The OG image link for proposals was passing the full proposal data creating a query parameter that was too long. This update only passes the required parts of the proposal object to the api.

## Motivation & context

fixes #170 

## Code review

- check that proposal og images work for all proposals

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have done a self-review of my own code
- [x] Any new and existing tests pass locally with my changes
- [x] My changes generate no new warnings (lint warnings, console warnings, etc)
