### PR TITLE
update url path on artwork upload

### DIFF
--- a/apps/web/src/modules/create-dao/components/Artwork/ArtworkUpload.tsx
+++ b/apps/web/src/modules/create-dao/components/Artwork/ArtworkUpload.tsx
@@ -124,7 +124,9 @@ export const ArtworkUpload: React.FC<ArtworkFormProps> = ({
           uri: upload?.ipfs?.uri || '',
           url: encodeURI(
             getFetchableUrl(upload?.ipfs?.uri) +
-              `/${upload.webkitRelativePath.split('/').slice(1).join('/')}` || ''
+              `/${sanitizeFileName(
+                upload.webkitRelativePath.split('/').slice(1).join('/')
+              )}` || ''
           ),
           path: upload.webkitRelativePath,
           content: upload?.content,


### PR DESCRIPTION
## Description

We're getting 404's resolving for ipfs files that might require file name sanitization

## Motivation & context

Turns out we are not sanitizing the path name when updating the url we store locally. This is causing the layers to 404 for unsanitised file paths.
## Code review

<!--- Any notes for code review? -->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have done a self-review of my own code
- [x] Any new and existing tests pass locally with my changes
- [x] My changes generate no new warnings (lint warnings, console warnings, etc)
