### PR TITLE
Fix issue where 0% allocation founders are not filtered

### DIFF
--- a/apps/web/src/modules/dao/components/About/About.tsx
+++ b/apps/web/src/modules/dao/components/About/About.tsx
@@ -142,9 +142,11 @@ export const About: React.FC = () => {
             Founders
           </Text>
           <Grid columns={isMobile ? 1 : 2} mt="x6" gap="x4">
-            {founders.map((founder) => (
-              <Founder {...founder} />
-            ))}
+            {founders
+              .filter((founder) => founder.ownershipPct > 0)
+              .map((founder) => (
+                <Founder key={founder.wallet} {...founder} />
+              ))}
           </Grid>
         </>
       ) : null}


### PR DESCRIPTION
## Description

Founders with 0% allocation are not being filtered on DAO about page

## Motivation & context

fixes #178 

## Code review

- are 0% founders being correctly filtered?

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have done a self-review of my own code
- [x] Any new and existing tests pass locally with my changes
- [x] My changes generate no new warnings (lint warnings, console warnings, etc)
