### PR TITLE
Update create proposal flow

### DIFF
--- a/apps/web/src/modules/create-proposal/components/CreateProposalHeading.tsx
+++ b/apps/web/src/modules/create-proposal/components/CreateProposalHeading.tsx
@@ -3,18 +3,22 @@ import React from 'react'
 
 import { ProposalNavigation } from 'src/modules/proposal'
 
+import { TransactionType } from '../constants'
+
 interface CreateProposalHeadingProps {
   title: string
+  transactionType?: TransactionType
   align?: 'center' | 'left'
 }
 
 export const CreateProposalHeading: React.FC<CreateProposalHeadingProps> = ({
   title,
+  transactionType,
   align = 'left',
 }) => {
   return (
     <Stack mx={'auto'} pb={'x8'} w={'100%'}>
-      <ProposalNavigation />
+      <ProposalNavigation transactionType={transactionType} />
       <Text
         fontSize={35}
         fontWeight={'label'}

--- a/apps/web/src/modules/create-proposal/components/Queue/Queue.tsx
+++ b/apps/web/src/modules/create-proposal/components/Queue/Queue.tsx
@@ -1,5 +1,4 @@
 import { Button, Flex, Stack, Text } from '@zoralabs/zord'
-import Link from 'next/link'
 import React from 'react'
 
 import AnimatedModal from 'src/components/Modal/AnimatedModal'
@@ -9,10 +8,10 @@ import { TransactionType } from '../../constants'
 import { ConfirmRemove } from './ConfirmRemove'
 
 interface QueueProps {
-  collectionAddress: string
+  setQueueModalOpen: (value: boolean) => void
 }
 
-export const Queue: React.FC<QueueProps> = ({ collectionAddress }) => {
+export const Queue: React.FC<QueueProps> = ({ setQueueModalOpen }) => {
   const transactions = useProposalStore((state) => state.transactions)
   const removeTransaction = useProposalStore((state) => state.removeTransaction)
   const removeAllTransactions = useProposalStore((state) => state.removeAllTransactions)
@@ -39,14 +38,7 @@ export const Queue: React.FC<QueueProps> = ({ collectionAddress }) => {
   }
 
   return (
-    <Stack
-      style={{ maxWidth: 500, borderRadius: 16 }}
-      borderWidth={'normal'}
-      borderStyle={'solid'}
-      borderColor={'ghostHover'}
-      p={'x6'}
-      pb={'x12'}
-    >
+    <Stack style={{ maxWidth: 500, borderRadius: 16 }}>
       <Flex justify={'space-between'}>
         <Text fontWeight={'label'} fontSize={20} style={{ lineHeight: '32px' }} mb={'x6'}>
           Review Queue
@@ -57,15 +49,16 @@ export const Queue: React.FC<QueueProps> = ({ collectionAddress }) => {
       </Flex>
 
       <Stack gap={'x4'}>
-        {transactions &&
-          transactions.map((transaction, i) => (
-            <TransactionCard
-              key={`${transaction.type}-${i}`}
-              handleRemove={() => confirmRemoveTransaction(i)}
-              disabled={transaction.type === TransactionType.UPGRADE}
-              transaction={transaction}
-            />
-          ))}
+        {transactions
+          ? transactions.map((transaction, i) => (
+              <TransactionCard
+                key={`${transaction.type}-${i}`}
+                handleRemove={() => confirmRemoveTransaction(i)}
+                disabled={transaction.type === TransactionType.UPGRADE}
+                transaction={transaction}
+              />
+            ))
+          : null}
       </Stack>
       <Stack
         borderWidth={'thin'}
@@ -74,30 +67,7 @@ export const Queue: React.FC<QueueProps> = ({ collectionAddress }) => {
         mt={'x6'}
         mb={'x8'}
       />
-
-      <Link
-        href={{
-          pathname: `/dao/${collectionAddress}/proposal/review`,
-        }}
-      >
-        <Flex
-          as={'button'}
-          py={'x4'}
-          px={'x6'}
-          mt={'x10'}
-          align={'center'}
-          justify={'center'}
-          disabled={transactions.length === 0}
-          borderRadius={'curved'}
-          backgroundColor={'accent'}
-          color={'onAccent'}
-          borderWidth={'none'}
-          cursor={'pointer'}
-          w={'100%'}
-        >
-          <Text variant={'label-lg'}>Review Proposal</Text>
-        </Flex>
-      </Link>
+      <Button onClick={() => setQueueModalOpen(false)}>Close</Button>
       <AnimatedModal close={() => setOpenConfirm(false)} open={openConfirm}>
         <ConfirmRemove
           handleRemoveTransaction={handleRemoveTransaction}

--- a/apps/web/src/modules/proposal/components/ProposalNavigation.tsx
+++ b/apps/web/src/modules/proposal/components/ProposalNavigation.tsx
@@ -1,21 +1,30 @@
-import { Box, Flex, Text } from '@zoralabs/zord'
+import { Box, Button, Flex, Text } from '@zoralabs/zord'
 import { getFetchableUrl } from 'ipfs-service'
 import Image from 'next/legacy/image'
 import { useRouter } from 'next/router'
-import React from 'react'
+import React, { useState } from 'react'
 import { useContractReads } from 'wagmi'
 
 import { Icon } from 'src/components/Icon'
+import AnimatedModal from 'src/components/Modal/AnimatedModal'
+import { OptionalLink } from 'src/components/OptionalLink'
 import { metadataAbi, tokenAbi } from 'src/data/contract/abis'
+import { Queue, TransactionType, useProposalStore } from 'src/modules/create-proposal'
 import { useDaoStore } from 'src/modules/dao'
 
 interface ProposalNavigationProps {
+  transactionType?: TransactionType
   handleBack?: () => void
 }
 
-export const ProposalNavigation: React.FC<ProposalNavigationProps> = ({ handleBack }) => {
+export const ProposalNavigation: React.FC<ProposalNavigationProps> = ({
+  transactionType,
+  handleBack,
+}) => {
   const router = useRouter()
   const addresses = useDaoStore((state) => state.addresses)
+  const transactions = useProposalStore((state) => state.transactions)
+  const [queueModalOpen, setQueueModalOpen] = useState(false)
 
   const token = addresses?.token
   const metadata = addresses?.metadata
@@ -34,7 +43,7 @@ export const ProposalNavigation: React.FC<ProposalNavigationProps> = ({ handleBa
 
   return (
     <Flex direction={'column'} w={'100%'} align={'center'} mt={'x8'}>
-      <Flex w={'100%'}>
+      <Flex w={'100%'} justify="space-between">
         <Box onClick={handleNavigation} aria-label="Back" cursor={'pointer'}>
           <Flex direction={'row'} align={'center'} gap={'x2'}>
             <Icon id="arrowLeft" />
@@ -66,7 +75,25 @@ export const ProposalNavigation: React.FC<ProposalNavigationProps> = ({ handleBa
             )}
           </Flex>
         </Box>
+        {transactionType ? (
+          <Box>
+            <Flex>
+              <Button mr="x6" variant="secondary" onClick={() => setQueueModalOpen(true)}>
+                {`${transactions.length} transactions queued`}
+              </Button>
+              <OptionalLink
+                enabled={!!transactions.length}
+                href={`/dao/${token}/proposal/review`}
+              >
+                <Button disabled={!transactions.length}>Continue</Button>
+              </OptionalLink>
+            </Flex>
+          </Box>
+        ) : null}
       </Flex>
+      <AnimatedModal close={() => setQueueModalOpen(false)} open={queueModalOpen}>
+        <Queue setQueueModalOpen={setQueueModalOpen} />
+      </AnimatedModal>
     </Flex>
   )
 }

--- a/apps/web/src/pages/dao/[token]/proposal/create.tsx
+++ b/apps/web/src/pages/dao/[token]/proposal/create.tsx
@@ -11,7 +11,6 @@ import { getDaoLayout } from 'src/layouts/DaoLayout'
 import {
   CreateProposalHeading,
   DropdownSelect,
-  Queue,
   SelectTransactionType,
   TRANSACTION_FORM_OPTIONS,
   TRANSACTION_TYPES,
@@ -29,7 +28,6 @@ import { AddressType } from 'src/typings'
 const CreateProposalPage: NextPageWithLayout = () => {
   const router = useRouter()
   const { query } = router
-  const collectionAddress = query?.token as AddressType
   const [transactionType, setTransactionType] = useState<TransactionType | undefined>()
   const transactions = useProposalStore((state) => state.transactions)
 
@@ -75,7 +73,10 @@ const CreateProposalPage: NextPageWithLayout = () => {
       style={{ maxWidth: 1060 }}
       mx="auto"
     >
-      <CreateProposalHeading title={'Create Proposal'} />
+      <CreateProposalHeading
+        title={'Create Proposal'}
+        transactionType={transactionType}
+      />
       {transactionType ? (
         <TwoColumnLayout
           leftColumn={
@@ -88,7 +89,6 @@ const CreateProposalPage: NextPageWithLayout = () => {
               <TransactionForm type={transactionType} />
             </Stack>
           }
-          rightColumn={<Queue collectionAddress={collectionAddress} />}
         />
       ) : (
         <TwoColumnLayout


### PR DESCRIPTION
## Description

simplify proposal creation by moving transaction queue to a modal

## Motivation & context

- users were getting stuck on the proposal creation page 
- we need more room to add previews for bigger proposal templates like droposals

## Code review

- are proposal template forms are still functioning correctly
- is the transaction queue modal retaining all functionality
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have done a self-review of my own code
- [x] Any new and existing tests pass locally with my changes
- [x] My changes generate no new warnings (lint warnings, console warnings, etc)
