### PR TITLE
Fix address debounce issue

### DIFF
--- a/apps/web/src/modules/create-dao/components/AllocationForm/AllocationForm.schema.ts
+++ b/apps/web/src/modules/create-dao/components/AllocationForm/AllocationForm.schema.ts
@@ -15,15 +15,14 @@ const validateAddress = async (
   }
 }
 
-export const deboucedValidateAddress = debounce(validateAddress, 500)
+export const deboucedValidateAddress = async (value: string | undefined) => {
+  const debouncedFn = debounce(validateAddress, 500)
+  return await new Promise<boolean>((res) => debouncedFn(value, res))
+}
 
 export const allocationSchema = Yup.object().shape({
   founderAddress: Yup.string()
-    .test(
-      'isValidAddress',
-      'invalid address',
-      (value) => new Promise((res) => deboucedValidateAddress(value, res))
-    )
+    .test('isValidAddress', 'invalid address', deboucedValidateAddress)
     .required('*'),
   allocationPercentage: Yup.number()
     .transform((value) => (isNaN(value) ? undefined : value))

--- a/apps/web/src/modules/create-dao/components/VetoForm.tsx
+++ b/apps/web/src/modules/create-dao/components/VetoForm.tsx
@@ -41,11 +41,7 @@ export const vetoValidationSchema = Yup.object().shape({
     is: true,
     then: Yup.string()
       .required('*')
-      .test(
-        'isValidAddress',
-        'invalid address',
-        (value) => new Promise((res) => deboucedValidateAddress(value, res))
-      ),
+      .test('isValidAddress', 'invalid address', deboucedValidateAddress),
   }),
 })
 


### PR DESCRIPTION
## Description

Address validation is debouncing for every call not on a per address basis causing validation issues when multiple address fields exist on one page.


## Code review

- is address validation working properly
- are forms with multiple address fields debouncing properly

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have done a self-review of my own code
- [x] Any new and existing tests pass locally with my changes
- [x] My changes generate no new warnings (lint warnings, console warnings, etc)
