### PR TITLE
Fix DAO website validation

### DIFF
--- a/apps/web/src/utils/yup/url.schema.ts
+++ b/apps/web/src/utils/yup/url.schema.ts
@@ -1,7 +1,7 @@
 import * as Yup from 'yup'
 
 const re =
-  /^((ftp|http|https):\/\/)?(www.)?(?!.*(ftp|http|https|www.))[a-zA-Z0-9_-]+(\.[a-zA-Z]+)+((\/)[\w#]+)*(\/\w+\?[a-zA-Z0-9_]+=\w+(&[a-zA-Z0-9_]+=\w+)*)?$/gm
+  /^((ftp|http|https):\/\/)(www.)?(?!.*(ftp|http|https|www.))[a-zA-Z0-9_-]+(\.[a-zA-Z]+)+((\/)[\w#]+)*(\/\w+\?[a-zA-Z0-9_]+=\w+(&[a-zA-Z0-9_]+=\w+)*)?$/gm
 
 export const urlValidationSchema = Yup.string()
   .transform((value: string) => value.replace(/\/$/, ''))


### PR DESCRIPTION
## Description

The regex for URL validation does not ensure that the protocol is specified for the DAO website leading to multiple DAOs with broken links (test.com instead of https://test.com). This change removes the optional check for the protocol at the beginning of the string.

## Motivation & context

fixes #204 

## Code review

- does website validation correctly require a protocol?
- should this issue be fixed in another way? (appending https to empty urls?)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have done a self-review of my own code
- [x] Any new and existing tests pass locally with my changes
- [x] My changes generate no new warnings (lint warnings, console warnings, etc)
