### PR TITLE
Fix place bid button when no wallet is connected

### DIFF
--- a/apps/web/src/modules/auction/components/CurrentAuction/PlaceBid.tsx
+++ b/apps/web/src/modules/auction/components/CurrentAuction/PlaceBid.tsx
@@ -3,7 +3,14 @@ import { Box, Button, Flex } from '@zoralabs/zord'
 import { BigNumber, ethers } from 'ethers'
 import React, { Fragment, memo, useState } from 'react'
 import { useSWRConfig } from 'swr'
-import { Address, useAccount, useBalance, useContractReads, useSigner } from 'wagmi'
+import {
+  Address,
+  useAccount,
+  useBalance,
+  useContractReads,
+  useNetwork,
+  useSigner,
+} from 'wagmi'
 
 import { ContractButton } from 'src/components/ContractButton'
 import SWR_KEYS from 'src/constants/swrKeys'
@@ -24,6 +31,7 @@ interface PlaceBidProps {
 export const PlaceBid = ({ highestBid, tokenId }: PlaceBidProps) => {
   const { data: signer } = useSigner()
   const { address } = useAccount()
+  const { chain } = useNetwork()
   const { data: balance } = useBalance({ address: address })
   const { mutate } = useSWRConfig()
   const { addresses } = useDaoStore()
@@ -108,7 +116,7 @@ export const PlaceBid = ({ highestBid, tokenId }: PlaceBidProps) => {
           <ContractButton
             className={auctionActionButtonVariants['bid']}
             handleClick={handleCreateBid}
-            disabled={!isMinBid || !bidAmount || !signer}
+            disabled={address && !chain?.unsupported ? !isMinBid || !bidAmount : false}
             mt={{ '@initial': 'x2', '@768': 'x0' }}
           >
             Place bid


### PR DESCRIPTION
## Description

Fixes an issue where the place bid button would not show the connect wallet modal when user was not connected.

## Motivation & context    

closes #212
replaces #213 

## Code review

- does the place bid button show the connect wallet modal when a user is not connected
- does the button show the network modal when a user is on the wrong network
- does bidding still validate properly

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have done a self-review of my own code
- [x] Any new and existing tests pass locally with my changes
- [x] My changes generate no new warnings (lint warnings, console warnings, etc)
