### PR TITLE
Fix style for long proposal titles

### DIFF
--- a/apps/web/src/modules/proposal/components/ProposalCard.css.ts
+++ b/apps/web/src/modules/proposal/components/ProposalCard.css.ts
@@ -5,7 +5,7 @@ export const titleStyle = style([
   {
     order: 2,
     '@media': {
-      [media.min768]: { order: 1 },
+      [media.min768]: { order: 1, width: '65%' },
     },
   },
 ])


### PR DESCRIPTION
## Description

Sets a max width for long proposal titles on desktop

## Motivation & context

closes #215 

## Code review

do proposals format correctly on mobile and desktop for normal and long proposals

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have done a self-review of my own code
- [x] Any new and existing tests pass locally with my changes
- [x] My changes generate no new warnings (lint warnings, console warnings, etc)
