### PR TITLE
Fix formatting issues with long text on proposal templates

### DIFF
--- a/apps/web/src/modules/create-proposal/components/TransactionForm/CustomTransaction/forms/Summary/Summary.tsx
+++ b/apps/web/src/modules/create-proposal/components/TransactionForm/CustomTransaction/forms/Summary/Summary.tsx
@@ -155,7 +155,9 @@ export const Summary: React.FC<SummaryProps> = ({ setIsOpen }) => {
       </Flex>
       <Flex justify={'space-between'} align={'center'}>
         <Flex fontWeight={'label'}>Function</Flex>
-        <Flex>{customTransaction?.function.name}</Flex>
+        <Flex style={{ wordBreak: 'break-word' }} ml="x6">
+          {customTransaction?.function.name}
+        </Flex>
       </Flex>
       <Flex justify={'space-between'} align={'center'} mb={'x4'}>
         <Flex fontWeight={'label'}>Arguments</Flex>

--- a/apps/web/src/modules/create-proposal/components/TransactionForm/Droposal/Droposal.css.ts
+++ b/apps/web/src/modules/create-proposal/components/TransactionForm/Droposal/Droposal.css.ts
@@ -1,6 +1,12 @@
 import { style } from '@vanilla-extract/css'
 import { atoms } from '@zoralabs/zord'
 
+export const previewTextStyle = style({
+  whiteSpace: 'pre-wrap',
+  wordBreak: 'break-word',
+  maxWidth: '400px',
+})
+
 export const defaultInputLabelStyle = style([
   atoms({
     display: 'inline-flex',

--- a/apps/web/src/modules/create-proposal/components/TransactionForm/Droposal/DroposalPreview.tsx
+++ b/apps/web/src/modules/create-proposal/components/TransactionForm/Droposal/DroposalPreview.tsx
@@ -3,6 +3,7 @@ import { FormikProps } from 'formik'
 
 import { MediaPreview } from 'src/components/MediaPreview/MediaPreview'
 
+import { previewTextStyle } from './Droposal.css'
 import { DroposalFormValues } from './DroposalForm.schema'
 
 interface DroposalPreviewProps {
@@ -26,7 +27,7 @@ export const DroposalPreview: React.FC<DroposalPreviewProps> = ({ formik }) => {
         <Box style={{ width: '400px', height: '400px' }}>
           <MediaPreview mediaUrl={mediaUrl} coverUrl={coverUrl} mediaType={mediaType} />
         </Box>
-        <Text mt="x4" variant="heading-sm">
+        <Text mt="x4" variant="heading-sm" className={previewTextStyle}>
           {name || 'Collection name'}
         </Text>
         <Flex mt="x2" align={'center'}>
@@ -43,7 +44,14 @@ export const DroposalPreview: React.FC<DroposalPreviewProps> = ({ formik }) => {
             EDITION
           </Text>
         </Flex>
-        <Text mt="x2" variant={'paragraph-lg'} style={{ fontWeight: 500 }}>
+        <Text
+          mt="x2"
+          variant={'paragraph-lg'}
+          className={previewTextStyle}
+          style={{
+            fontWeight: 500,
+          }}
+        >
           {description || 'description'}
         </Text>
         <Flex mt="x4">


### PR DESCRIPTION
## Description

Long text on custom transaction + droposal proposal templates was not being wrapped properly.

## Motivation & context

closes #240 

## Code review

Does text wrap properly

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have done a self-review of my own code
- [x] Any new and existing tests pass locally with my changes
- [x] My changes generate no new warnings (lint warnings, console warnings, etc)
