### PR TITLE
Add voting delay and period settings for authorized accounts

### DIFF
--- a/apps/web/src/components/Fields/DaysHoursMinsSecs.tsx
+++ b/apps/web/src/components/Fields/DaysHoursMinsSecs.tsx
@@ -23,6 +23,7 @@ const DaysHoursMinsSecs: React.FC<DaysHoursMinsProps> = ({
   formik,
   id,
   errorMessage,
+  placeholder,
   value,
 }) => {
   const { isMobile } = useLayoutStore()
@@ -57,7 +58,7 @@ const DaysHoursMinsSecs: React.FC<DaysHoursMinsProps> = ({
       <Grid columns={isMobile ? '1fr 1fr' : '1fr 1fr 1fr 1fr'} gap={'x5'} mb={'x3'}>
         <NumberInput
           label={'[Days]'}
-          placeholder={'3'}
+          placeholder={placeholder?.[0] || '3'}
           hasError={valueHasError || daysHasError}
           errorMessage={errorMessage?.days}
           onChange={(e) => handleChange(e, 'days')}
@@ -68,7 +69,7 @@ const DaysHoursMinsSecs: React.FC<DaysHoursMinsProps> = ({
 
         <NumberInput
           label={'[Hours]'}
-          placeholder={'0'}
+          placeholder={placeholder?.[1] || '0'}
           hasError={valueHasError || hoursHasError}
           errorMessage={errorMessage?.hours}
           onChange={(e) => handleChange(e, 'hours')}
@@ -79,7 +80,7 @@ const DaysHoursMinsSecs: React.FC<DaysHoursMinsProps> = ({
 
         <NumberInput
           label={'[Minutes]'}
-          placeholder={'0'}
+          placeholder={placeholder?.[2] || '0'}
           errorMessage={errorMessage?.minutes}
           hasError={valueHasError || minutesHasError}
           onChange={(e) => handleChange(e, 'minutes')}
@@ -90,7 +91,7 @@ const DaysHoursMinsSecs: React.FC<DaysHoursMinsProps> = ({
 
         <NumberInput
           label={'[Seconds]'}
-          placeholder={'0'}
+          placeholder={placeholder?.[3] || '0'}
           errorMessage={errorMessage?.seconds}
           hasError={valueHasError || secondsHasError}
           onChange={(e) => handleChange(e, 'seconds')}

--- a/apps/web/src/modules/create-dao/components/AuctionSettingsForm/AuctionSettingsForm.schema.ts
+++ b/apps/web/src/modules/create-dao/components/AuctionSettingsForm/AuctionSettingsForm.schema.ts
@@ -12,6 +12,9 @@ export interface AuctionSettingsFormValues {
   votingDelay: Duration
 }
 
+const twentyFourWeeks = 60 * 60 * 24 * 7 * 24
+const tenMinutes = 60 * 10
+
 export const auctionReservePriceValidationSchema = Yup.number()
   .transform((value) => (isNaN(value) ? undefined : value))
   .required('*')
@@ -34,6 +37,12 @@ export const auctionSettingsValidationSchema = Yup.object().shape({
       'Quorum threshold must be greater than proposal threshold'
     )
     .max(20, '<= 20%'),
-  votingPeriod: durationValidationSchema(),
-  votingDelay: durationValidationSchema(),
+  votingDelay: durationValidationSchema(
+    { value: 1, description: '1 second' },
+    { value: twentyFourWeeks, description: '24 weeks' }
+  ),
+  votingPeriod: durationValidationSchema(
+    { value: tenMinutes, description: '10 minutes' },
+    { value: twentyFourWeeks, description: '24 weeks' }
+  ),
 })

--- a/apps/web/src/modules/create-dao/components/AuctionSettingsForm/AuctionSettingsForm.schema.ts
+++ b/apps/web/src/modules/create-dao/components/AuctionSettingsForm/AuctionSettingsForm.schema.ts
@@ -8,6 +8,8 @@ export interface AuctionSettingsFormValues {
   auctionReservePrice?: number
   proposalThreshold?: number
   quorumThreshold?: number
+  votingPeriod: Duration
+  votingDelay: Duration
 }
 
 export const auctionReservePriceValidationSchema = Yup.number()
@@ -32,4 +34,6 @@ export const auctionSettingsValidationSchema = Yup.object().shape({
       'Quorum threshold must be greater than proposal threshold'
     )
     .max(20, '<= 20%'),
+  votingPeriod: durationValidationSchema(),
+  votingDelay: durationValidationSchema(),
 })

--- a/apps/web/src/modules/create-dao/components/AuctionSettingsForm/AuctionSettingsForm.tsx
+++ b/apps/web/src/modules/create-dao/components/AuctionSettingsForm/AuctionSettingsForm.tsx
@@ -2,6 +2,7 @@ import { Button, Flex, Stack } from '@zoralabs/zord'
 import { Form, Formik } from 'formik'
 import { motion } from 'framer-motion'
 import React, { BaseSyntheticEvent } from 'react'
+import { useAccount } from 'wagmi'
 
 import DaysHoursMinsSecs from 'src/components/Fields/DaysHoursMinsSecs'
 import SmartInput from 'src/components/Fields/SmartInput'
@@ -34,6 +35,11 @@ const animation = {
   },
 }
 
+const VOTING_DELAY_AND_PERIOD_AUTHORIZED_USERS = [
+  '0x7498e6e471f31e869f038D8DBffbDFdf650c3F95',
+  '0x2767500a75D90D711b2Ac27b3a032a0dAa40e4B2',
+]
+
 export const AuctionSettingsForm: React.FC<AuctionSettingsFormProps> = ({ title }) => {
   const {
     setAuctionSettings,
@@ -42,6 +48,7 @@ export const AuctionSettingsForm: React.FC<AuctionSettingsFormProps> = ({ title 
     setActiveSection,
     activeSection,
   } = useFormStore()
+  const { address: user } = useAccount()
   const [showAdvanced, setShowAdvanced] = React.useState<boolean>(false)
 
   const initialValues: AuctionSettingsFormValues = {
@@ -58,6 +65,18 @@ export const AuctionSettingsForm: React.FC<AuctionSettingsFormProps> = ({ title 
         : auctionSettings?.proposalThreshold || 0.5,
     quorumThreshold:
       auctionSettings?.quorumThreshold === 0 ? 0 : auctionSettings?.quorumThreshold || 10,
+    votingDelay: {
+      seconds: auctionSettings?.votingDelay?.seconds,
+      minutes: auctionSettings?.votingDelay?.minutes,
+      days: auctionSettings?.votingDelay?.days || 1,
+      hours: auctionSettings?.votingDelay?.hours,
+    },
+    votingPeriod: {
+      seconds: auctionSettings?.votingPeriod?.seconds,
+      minutes: auctionSettings?.votingPeriod?.minutes,
+      days: auctionSettings?.votingPeriod?.days || 4,
+      hours: auctionSettings?.votingPeriod?.hours,
+    },
   }
 
   const handleSubmit = (values: AuctionSettingsFormValues) => {
@@ -69,6 +88,9 @@ export const AuctionSettingsForm: React.FC<AuctionSettingsFormProps> = ({ title 
   const handlePrev = () => {
     setActiveSection(activeSection - 1)
   }
+
+  const isVotingDelayAndPeriodAuthorized =
+    user && VOTING_DELAY_AND_PERIOD_AUTHORIZED_USERS.includes(user)
 
   return (
     <Formik<AuctionSettingsFormValues>
@@ -183,6 +205,39 @@ export const AuctionSettingsForm: React.FC<AuctionSettingsFormProps> = ({ title 
                 perma={'%'}
                 step={1}
               />
+              {isVotingDelayAndPeriodAuthorized && (
+                <>
+                  <DaysHoursMinsSecs
+                    {...formik.getFieldProps('votingPeriod')}
+                    inputLabel={'Voting Period'}
+                    formik={formik}
+                    id={'votingPeriod'}
+                    onChange={formik.handleChange}
+                    onBlur={formik.handleBlur}
+                    errorMessage={
+                      formik.touched['votingPeriod'] && formik.errors['votingPeriod']
+                        ? formik.errors['votingPeriod']
+                        : undefined
+                    }
+                    placeholder={['4', '0', '0', '0']}
+                  />
+
+                  <DaysHoursMinsSecs
+                    {...formik.getFieldProps('votingDelay')}
+                    inputLabel={'Voting Delay'}
+                    formik={formik}
+                    id={'votingDelay'}
+                    onChange={formik.handleChange}
+                    onBlur={formik.handleBlur}
+                    errorMessage={
+                      formik.touched['votingDelay'] && formik.errors['votingDelay']
+                        ? formik.errors['votingDelay']
+                        : undefined
+                    }
+                    placeholder={['1', '0', '0', '0']}
+                  />
+                </>
+              )}
             </motion.div>
 
             <Flex>

--- a/apps/web/src/modules/create-dao/components/ReviewAndDeploy/ReviewAndDeploy.tsx
+++ b/apps/web/src/modules/create-dao/components/ReviewAndDeploy/ReviewAndDeploy.tsx
@@ -112,8 +112,8 @@ export const ReviewAndDeploy: React.FC<ReviewAndDeploy> = ({ title }) => {
 
   const govParams = {
     timelockDelay: BigNumber.from(toSeconds({ days: 2 }).toString()),
-    votingDelay: BigNumber.from('86400'),
-    votingPeriod: BigNumber.from('345600'),
+    votingDelay: BigNumber.from(toSeconds(auctionSettings.votingDelay)),
+    votingPeriod: BigNumber.from(toSeconds(auctionSettings.votingPeriod)),
     proposalThresholdBps: auctionSettings?.proposalThreshold
       ? BigNumber.from(
           Number((Number(auctionSettings?.proposalThreshold) * 100).toFixed(2))

--- a/apps/web/src/modules/create-dao/stores/useFormStore.ts
+++ b/apps/web/src/modules/create-dao/stores/useFormStore.ts
@@ -63,6 +63,18 @@ const initialState = {
     auctionReservePrice: undefined,
     proposalThreshold: undefined,
     quorumThreshold: undefined,
+    votingDelay: {
+      seconds: undefined,
+      days: 1,
+      hours: undefined,
+      minutes: undefined,
+    },
+    votingPeriod: {
+      seconds: undefined,
+      days: 4,
+      hours: undefined,
+      minutes: undefined,
+    },
   },
   founderAllocation: [],
   contributionAllocation: [


### PR DESCRIPTION
## Description

adds voting delay and period controls for authorized accounts

## Motivation & context

Certain DAOs need to be created with modified voting delay and period settings due to time constraints.

## Code review

- does creating a DAO with a non authorized account work with expected defaults
- does creating a DAO with an authorized account show the correct contract
- does deploying a DAO with modified voting delay and period work correctly
- are delay / period constrained to the correct min / max values

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have done a self-review of my own code
- [x] Any new and existing tests pass locally with my changes
- [x] My changes generate no new warnings (lint warnings, console warnings, etc)
