### PR TITLE
Fix droposal open edition issues

### DIFF
--- a/apps/web/src/modules/create-proposal/components/TransactionForm/Droposal/Droposal.tsx
+++ b/apps/web/src/modules/create-proposal/components/TransactionForm/Droposal/Droposal.tsx
@@ -43,7 +43,7 @@ export const Droposal: React.FC = () => {
     const royaltyBPS = royaltyPercentage * 100
     const salesConfig = [
       ethers.utils.parseEther((publicSalePrice || 0).toString()),
-      maxSalePurchasePerAddress,
+      maxSalePurchasePerAddress || 0,
       BigNumber.from(Math.floor(new Date(publicSaleStart).getTime() / 1000)),
       BigNumber.from(Math.floor(new Date(publicSaleEnd).getTime() / 1000)),
       0, // presaleStart

--- a/apps/web/src/modules/create-proposal/components/TransactionForm/Droposal/Droposal.tsx
+++ b/apps/web/src/modules/create-proposal/components/TransactionForm/Droposal/Droposal.tsx
@@ -12,6 +12,9 @@ import { AddressType } from 'src/typings'
 import { DroposalForm } from './DroposalForm'
 import { DroposalFormValues } from './DroposalForm.schema'
 
+const UINT_64_MAX = 18446744073709551615
+const UINT_32_MAX = 4294967295
+
 export const Droposal: React.FC = () => {
   const addTransaction = useProposalStore((state) => state.addTransaction)
   const zoraNFTCreatorContract = useContract({
@@ -43,7 +46,7 @@ export const Droposal: React.FC = () => {
     const royaltyBPS = royaltyPercentage * 100
     const salesConfig = [
       ethers.utils.parseEther((publicSalePrice || 0).toString()),
-      maxSalePurchasePerAddress || 0,
+      maxSalePurchasePerAddress || UINT_32_MAX,
       BigNumber.from(Math.floor(new Date(publicSaleStart).getTime() / 1000)),
       BigNumber.from(Math.floor(new Date(publicSaleEnd).getTime() / 1000)),
       0, // presaleStart
@@ -62,7 +65,7 @@ export const Droposal: React.FC = () => {
           [
             name,
             symbol,
-            editionSize,
+            editionSize || UINT_64_MAX,
             royaltyBPS,
             fundsRecipient,
             defaultAdmin,

--- a/apps/web/src/modules/create-proposal/components/TransactionForm/Droposal/Droposal.tsx
+++ b/apps/web/src/modules/create-proposal/components/TransactionForm/Droposal/Droposal.tsx
@@ -12,8 +12,8 @@ import { AddressType } from 'src/typings'
 import { DroposalForm } from './DroposalForm'
 import { DroposalFormValues } from './DroposalForm.schema'
 
-const UINT_64_MAX = 18446744073709551615
-const UINT_32_MAX = 4294967295
+const UINT_64_MAX = BigNumber.from('18446744073709551615')
+const UINT_32_MAX = BigNumber.from('4294967295')
 
 export const Droposal: React.FC = () => {
   const addTransaction = useProposalStore((state) => state.addTransaction)

--- a/apps/web/src/modules/create-proposal/components/TransactionForm/Droposal/DroposalForm.schema.ts
+++ b/apps/web/src/modules/create-proposal/components/TransactionForm/Droposal/DroposalForm.schema.ts
@@ -10,7 +10,7 @@ export interface DroposalFormValues {
   mediaType?: string
   coverUrl: string
   pricePerMint: number
-  maxPerAddress: number
+  maxPerAddress?: number
   maxSupply: number
   royaltyPercentage: number
   fundsRecipient: string

--- a/apps/web/src/modules/create-proposal/components/TransactionForm/Droposal/DroposalForm.schema.ts
+++ b/apps/web/src/modules/create-proposal/components/TransactionForm/Droposal/DroposalForm.schema.ts
@@ -28,7 +28,7 @@ const droposalFormSchema = yup.object({
   coverUrl: yup.string(),
   pricePerMint: yup.number().required('*'),
   maxPerAddress: yup.number().integer('Must be whole number'),
-  maxSupply: yup.number().integer('Must be whole number'),
+  maxSupply: yup.number().required('*').integer('Must be whole number'),
   royaltyPercentage: yup.number().required('*'),
   defaultAdmin: yup
     .string()

--- a/apps/web/src/modules/create-proposal/components/TransactionForm/Droposal/DroposalForm.tsx
+++ b/apps/web/src/modules/create-proposal/components/TransactionForm/Droposal/DroposalForm.tsx
@@ -24,13 +24,15 @@ export interface AirdropFormProps {
   disabled?: boolean
 }
 
+export type EditionType = 'fixed' | 'open'
+
 const editionSizeOptions = [
   { label: 'Fixed', value: 'fixed' },
   { label: 'Open edition', value: 'open' },
 ]
 
 export const DroposalForm: React.FC<AirdropFormProps> = ({ onSubmit, disabled }) => {
-  const [editionType, setEditionType] = useState('fixed')
+  const [editionType, setEditionType] = useState<EditionType>('fixed')
   const [isIPFSUploading, setIsIPFSUploading] = useState(false)
   const { address: user } = useAccount()
   const { treasury } = useDaoStore((x) => x.addresses)
@@ -79,7 +81,7 @@ export const DroposalForm: React.FC<AirdropFormProps> = ({ onSubmit, disabled })
             value === 'open'
               ? formik.setFieldValue('maxSupply', 0)
               : formik.setFieldValue('maxSupply', undefined)
-            setEditionType(value)
+            setEditionType(value as EditionType)
           }
 
           const showCover = formik.values['mediaType']
@@ -88,7 +90,7 @@ export const DroposalForm: React.FC<AirdropFormProps> = ({ onSubmit, disabled })
 
           return (
             <>
-              {!isMobile && <DroposalPreview formik={formik} />}
+              {!isMobile && <DroposalPreview formik={formik} editionType={editionType} />}
               <Text
                 mb="x8"
                 ml="x2"

--- a/apps/web/src/modules/create-proposal/components/TransactionForm/Droposal/DroposalForm.tsx
+++ b/apps/web/src/modules/create-proposal/components/TransactionForm/Droposal/DroposalForm.tsx
@@ -50,7 +50,6 @@ export const DroposalForm: React.FC<AirdropFormProps> = ({ onSubmit, disabled })
     publicSaleEnd: '',
     royaltyPercentage: 5,
     pricePerMint: 0,
-    maxPerAddress: 1,
     maxSupply: 10,
   }
 

--- a/apps/web/src/modules/create-proposal/components/TransactionForm/Droposal/DroposalForm.tsx
+++ b/apps/web/src/modules/create-proposal/components/TransactionForm/Droposal/DroposalForm.tsx
@@ -77,8 +77,8 @@ export const DroposalForm: React.FC<AirdropFormProps> = ({ onSubmit, disabled })
 
           const handleEditionTypeChanged = (value: string) => {
             value === 'open'
-              ? formik.setFieldValue('editionSize', 0)
-              : formik.setFieldValue('editionSize', undefined)
+              ? formik.setFieldValue('maxSupply', 0)
+              : formik.setFieldValue('maxSupply', undefined)
             setEditionType(value)
           }
 

--- a/apps/web/src/modules/create-proposal/components/TransactionForm/Droposal/DroposalPreview.tsx
+++ b/apps/web/src/modules/create-proposal/components/TransactionForm/Droposal/DroposalPreview.tsx
@@ -4,13 +4,18 @@ import { FormikProps } from 'formik'
 import { MediaPreview } from 'src/components/MediaPreview/MediaPreview'
 
 import { previewTextStyle } from './Droposal.css'
+import { EditionType } from './DroposalForm'
 import { DroposalFormValues } from './DroposalForm.schema'
 
 interface DroposalPreviewProps {
   formik: FormikProps<DroposalFormValues>
+  editionType: EditionType
 }
 
-export const DroposalPreview: React.FC<DroposalPreviewProps> = ({ formik }) => {
+export const DroposalPreview: React.FC<DroposalPreviewProps> = ({
+  formik,
+  editionType,
+}) => {
   const {
     mediaUrl,
     coverUrl,
@@ -68,7 +73,7 @@ export const DroposalPreview: React.FC<DroposalPreviewProps> = ({ formik }) => {
               TOTAL SUPPLY
             </Text>
             <Text variant="heading-sm" style={{ fontWeight: 'bold' }}>
-              {maxSupply || 'OPEN'}
+              {editionType === 'fixed' ? maxSupply || '---' : 'OPEN'}
             </Text>
           </Box>
         </Flex>


### PR DESCRIPTION
## Description

- Add a default value for `maxSalePurchasePerAddress`
- Add a default value for `editionSize`
- Add required validation for `editionSize`

## Motivation & context

- `maxSalePurchasePerAddress` did not include a fallback value if the user removed the default value / didn't provide their own. It should be set it `UINT_32_MAX`
- `editionSize` was left set to zero on an open edition. Zora contracts require it to be set to `UINT_64_MAX`
- `editionSize` did not have a required validation so an issue could occur if the user left it  blank

## Code review

- does creating a droposal with no maxSalePurchasePerAddress work
- does creating a droposal as an open edition work
- is `editionSize` now required

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have done a self-review of my own code
- [x] Any new and existing tests pass locally with my changes
- [x] My changes generate no new warnings (lint warnings, console warnings, etc)
