### PR TITLE
Fix timezone and datepicker issues with droposal

### DIFF
--- a/apps/web/src/components/Fields/Date.tsx
+++ b/apps/web/src/components/Fields/Date.tsx
@@ -19,8 +19,11 @@ interface DateProps {
   id: string
   errorMessage: string | FormikErrors<any> | string[] | undefined | FormikErrors<any>[]
   value: any
+  altFormat?: string
+  dateFormat?: string
   placeholder?: string
   autoSubmit?: boolean
+  enableTime?: boolean
   parentValues?: any
   disabled?: boolean
 }
@@ -33,6 +36,9 @@ const Date: React.FC<DateProps> = ({
   autoSubmit,
   value,
   placeholder,
+  altFormat,
+  enableTime = false,
+  dateFormat = 'Y-m-d',
   disabled = false,
 }) => {
   const ref = React.useRef(null)
@@ -41,7 +47,10 @@ const Date: React.FC<DateProps> = ({
     if (!ref.current) return
 
     flatpickr(ref.current, {
-      dateFormat: 'Y-m-d',
+      enableTime,
+      dateFormat,
+      altInput: !!altFormat,
+      altFormat,
       onChange: (_selectedDates, dateStr, _instance) => {
         formik.setFieldValue(id, dateStr)
 

--- a/apps/web/src/modules/create-proposal/components/TransactionForm/Droposal/DroposalForm.tsx
+++ b/apps/web/src/modules/create-proposal/components/TransactionForm/Droposal/DroposalForm.tsx
@@ -3,10 +3,11 @@ import { Form, Formik, FormikHelpers } from 'formik'
 import { useCallback, useState } from 'react'
 import { useAccount } from 'wagmi'
 
+import DatePicker from 'src/components/Fields/Date'
 import SmartInput from 'src/components/Fields/SmartInput'
 import TextArea from 'src/components/Fields/TextArea'
 import { defaultHelperTextStyle } from 'src/components/Fields/styles.css'
-import { DATE, NUMBER, TEXT } from 'src/components/Fields/types'
+import { NUMBER, TEXT } from 'src/components/Fields/types'
 import SingleMediaUpload from 'src/components/SingleMediaUpload/SingleMediaUpload'
 import { DropdownSelect } from 'src/modules/create-proposal'
 import { useDaoStore } from 'src/modules/dao'
@@ -255,14 +256,17 @@ export const DroposalForm: React.FC<AirdropFormProps> = ({ onSubmit, disabled })
                     </Box>
                   )}
 
-                  <SmartInput
+                  <DatePicker
                     {...formik.getFieldProps('publicSaleStart')}
+                    placeholder={'yyyy-mm-dd'}
                     inputLabel={'Start time'}
-                    type={DATE}
                     formik={formik}
                     id={'publicSaleStart'}
-                    onChange={formik.handleChange}
-                    onBlur={formik.handleBlur}
+                    autoSubmit={false}
+                    disabled={false}
+                    enableTime={true}
+                    dateFormat="Z"
+                    altFormat="Y-m-d H:i"
                     errorMessage={
                       formik.touched['publicSaleStart'] &&
                       formik.errors['publicSaleStart']
@@ -271,14 +275,17 @@ export const DroposalForm: React.FC<AirdropFormProps> = ({ onSubmit, disabled })
                     }
                   />
 
-                  <SmartInput
+                  <DatePicker
                     {...formik.getFieldProps('publicSaleEnd')}
+                    placeholder={'yyyy-mm-dd'}
                     inputLabel={'End time'}
-                    type={DATE}
                     formik={formik}
                     id={'publicSaleEnd'}
-                    onChange={formik.handleChange}
-                    onBlur={formik.handleBlur}
+                    autoSubmit={false}
+                    disabled={false}
+                    enableTime={true}
+                    dateFormat="Z"
+                    altFormat="Y-m-d H:i"
                     errorMessage={
                       formik.touched['publicSaleEnd'] && formik.errors['publicSaleEnd']
                         ? formik.errors['publicSaleEnd']


### PR DESCRIPTION
## Description

Changes droposal date control to include time as well as format in ISO format to fix timezone issues.

## Motivation & context

- users are seeing discrepancies in the inputted dates vs actual dates due to timezone issues
- users could not set a time for droposals

## Code review

- does the new datepicker for droposals 
- do droposals correctly handle timezones now
- do the time controls work on the datepicker
- do the time controls introduce issues in other components the datepicker is used in

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have done a self-review of my own code
- [x] Any new and existing tests pass locally with my changes
- [x] My changes generate no new warnings (lint warnings, console warnings, etc)
