### PR TITLE
Change CI to run lint, type-check and test separately

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,6 +51,12 @@ jobs:
           path: ~/.foundry/cache/rpc/**/${{ env.ANVIL_BLOCK_NUMBER }}
           key: foundry-anvil-${{ env.ANVIL_BLOCK_NUMBER }}
 
+      - name: 👾 Run lint task
+        run: pnpm lint
+
+      - name: 👾 Run type check task
+        run: pnpm type-check
+
       - name: 🦀 Install Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -67,8 +73,8 @@ jobs:
       - name: 🚀 Launch Anvil
         run: anvil --fork-url $ANVIL_FORK_URL --fork-block-number $ANVIL_BLOCK_NUMBER &
 
-      - name: 👾 Run CI task
-        run: pnpm ci
+      - name: 👾 Run test task
+        run: pnpm test
 
       # Need to shutdown Anvil so cache gets created
       - name: 💤 Shutdown Anvil


### PR DESCRIPTION
## Description

Breaks out lint, type-check and test to their own CI tasks

## Motivation & context

changed to ensure we can view lint and type-check results for external contributors 

## Code review

does the CI config still work as expected

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have done a self-review of my own code
- [x] Any new and existing tests pass locally with my changes
- [x] My changes generate no new warnings (lint warnings, console warnings, etc)
