### PR TITLE
Fix chain logo loading speed

### DIFF
--- a/apps/web/src/layouts/DefaultLayout/NavMenu.tsx
+++ b/apps/web/src/layouts/DefaultLayout/NavMenu.tsx
@@ -147,6 +147,7 @@ export const NavMenu = () => {
                 <Flex align={'center'}>
                   <Box h="x6" w="x6">
                     <Image
+                      loading="eager"
                       style={{ height: 24, width: 24 }}
                       src={selectedChain.icon}
                       alt={selectedChain.name}


### PR DESCRIPTION
## Description

Adds `egar` to chain logos in chain switcher

## Motivation & context

improve chain logo loading speed in switcher since they are hidden by default

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have done a self-review of my own code
- [x] Any new and existing tests pass locally with my changes
- [x] My changes generate no new warnings (lint warnings, console warnings, etc)
