### PR TITLE
Fix issue with get provider function

### DIFF
--- a/apps/web/src/utils/provider.ts
+++ b/apps/web/src/utils/provider.ts
@@ -4,14 +4,13 @@ import { ethers } from 'ethers'
 import { RPC_URL } from 'src/constants/rpc'
 import { CHAIN_ID } from 'src/typings'
 
-let provider: Map<CHAIN_ID, Provider>
+let providerMap: Map<CHAIN_ID, Provider>
 
 export function getProvider(chainId: CHAIN_ID): Provider {
-  if (!provider) provider = new Map()
-  if (!provider.has(chainId)) {
-    provider = new Map()
+  if (!providerMap) providerMap = new Map()
+  if (!providerMap.has(chainId)) {
     // Use static provider to prevent re-querying for chain id since this won't change
-    provider.set(chainId, new ethers.providers.StaticJsonRpcProvider(RPC_URL[chainId]))
+    providerMap.set(chainId, new ethers.providers.StaticJsonRpcProvider(RPC_URL[chainId]))
   }
-  return provider.get(chainId)!
+  return providerMap.get(chainId)!
 }

--- a/apps/web/src/utils/provider.ts
+++ b/apps/web/src/utils/provider.ts
@@ -4,12 +4,14 @@ import { ethers } from 'ethers'
 import { RPC_URL } from 'src/constants/rpc'
 import { CHAIN_ID } from 'src/typings'
 
-let provider: undefined | Provider
+let provider: Map<CHAIN_ID, Provider>
 
-export function getProvider(chain: CHAIN_ID): Provider {
-  if (!provider) {
+export function getProvider(chainId: CHAIN_ID): Provider {
+  if (!provider) provider = new Map()
+  if (!provider.has(chainId)) {
+    provider = new Map()
     // Use static provider to prevent re-querying for chain id since this won't change
-    provider = new ethers.providers.StaticJsonRpcProvider(RPC_URL[chain])
+    provider.set(chainId, new ethers.providers.StaticJsonRpcProvider(RPC_URL[chainId]))
   }
-  return provider
+  return provider.get(chainId)!
 }


### PR DESCRIPTION
## Description

updates `getProvider` implementation to use a map to store multiple providers instead of a single provider

## Motivation & context

get provider was only instantiating once and caching based on the first chain it was called with causing issues when a user would switch chains

## Code review

- does getProvider work properly on multichain 
- can test via send eth  and other proposal templates that utilize it

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have done a self-review of my own code
- [x] Any new and existing tests pass locally with my changes
- [x] My changes generate no new warnings (lint warnings, console warnings, etc)
