### PR TITLE
Fix issue where admin page is not properly shown

### DIFF
--- a/apps/web/src/pages/dao/[network]/[token]/[tokenId].tsx
+++ b/apps/web/src/pages/dao/[network]/[token]/[tokenId].tsx
@@ -106,7 +106,7 @@ const TokenPage: NextPageWithLayout<TokenPageProps> = ({
     const baseSections = hasThreshold ? [...publicSections, adminSection] : publicSections
     return CAST_ENABLED.includes(collection)
       ? [...baseSections.slice(0, 1), daoFeed, ...baseSections.slice(1)]
-      : publicSections
+      : baseSections
   }, [hasThreshold, collection])
 
   const description = token?.description ?? ''


### PR DESCRIPTION
## Description

Fixes an issue where admin section was not shown when a DAO did not have feeds enabled

## Motivation & context

fixes #304 

## Code review

- is admin tab visible for daos with feeds disabled

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have done a self-review of my own code
- [x] Any new and existing tests pass locally with my changes
- [x] My changes generate no new warnings (lint warnings, console warnings, etc)
