### PR TITLE
Fix explore pagination

### DIFF
--- a/apps/web/src/data/subgraph/queries/exploreDaosPage.graphql
+++ b/apps/web/src/data/subgraph/queries/exploreDaosPage.graphql
@@ -3,12 +3,13 @@ query exploreDaosPage(
   $orderDirection: OrderDirection
   $where: Auction_filter
   $skip: Int
+  $first: Int
 ) {
   auctions(
     where: $where
     orderBy: $orderBy
     orderDirection: $orderDirection
-    first: 30
+    first: $first
     skip: $skip
   ) {
     ...ExploreDao

--- a/apps/web/src/data/subgraph/sdk.generated.ts
+++ b/apps/web/src/data/subgraph/sdk.generated.ts
@@ -1948,6 +1948,7 @@ export type ExploreDaosPageQueryVariables = Exact<{
   orderDirection?: InputMaybe<OrderDirection>
   where?: InputMaybe<Auction_Filter>
   skip?: InputMaybe<Scalars['Int']>
+  first?: InputMaybe<Scalars['Int']>
 }>
 
 export type ExploreDaosPageQuery = {
@@ -2242,12 +2243,13 @@ export const ExploreDaosPageDocument = gql`
     $orderDirection: OrderDirection
     $where: Auction_filter
     $skip: Int
+    $first: Int
   ) {
     auctions(
       where: $where
       orderBy: $orderBy
       orderDirection: $orderDirection
-      first: 30
+      first: $first
       skip: $skip
     ) {
       ...ExploreDao

--- a/apps/web/src/modules/dao/components/Explore/Explore.tsx
+++ b/apps/web/src/modules/dao/components/Explore/Explore.tsx
@@ -1,4 +1,4 @@
-import { Grid } from '@zoralabs/zord'
+import { Grid, Text } from '@zoralabs/zord'
 import { ethers } from 'ethers'
 import { useRouter } from 'next/router'
 import React, { Fragment } from 'react'
@@ -23,9 +23,11 @@ export const Explore: React.FC<ExploreProps> = ({ daos, hasNextPage, isLoading }
   const { pathname } = router
   const chain = useChainStore((x) => x.chain)
 
+  const page = router.query.page
+
   const handlePageBack = React.useCallback(() => {
     // user is on the first page
-    if (!router.query.page)
+    if (!page)
       return {
         pathname,
         query: {
@@ -34,12 +36,12 @@ export const Explore: React.FC<ExploreProps> = ({ daos, hasNextPage, isLoading }
       }
 
     // user is at least on the second page
-    return Number(router.query.page) > 2
+    return Number(page) > 2
       ? {
           pathname,
           query: {
             ...router.query,
-            page: Number(router.query.page) - 1,
+            page: Number(page) - 1,
           },
         }
       : {
@@ -48,17 +50,17 @@ export const Explore: React.FC<ExploreProps> = ({ daos, hasNextPage, isLoading }
   }, [router, pathname])
 
   const handlePageForward = React.useCallback(() => {
-    // there are more results to be fetched
+    // there are no more results to be fetched
     if (!hasNextPage)
       return {
         pathname,
         query: {
-          page: router.query.page,
+          page,
         },
       }
 
     // user is on the first page
-    if (!router.query.page)
+    if (!page)
       return {
         pathname,
         query: {
@@ -72,7 +74,7 @@ export const Explore: React.FC<ExploreProps> = ({ daos, hasNextPage, isLoading }
       pathname,
       query: {
         ...router.query,
-        page: Number(router.query.page) + 1,
+        page: Number(page) + 1,
       },
     }
   }, [router, daos?.length, pathname])
@@ -110,8 +112,25 @@ export const Explore: React.FC<ExploreProps> = ({ daos, hasNextPage, isLoading }
         </Fragment>
       ) : isLoading ? (
         <ExploreSkeleton />
-      ) : (
+      ) : !page ? (
         <ExploreNoDaos />
+      ) : (
+        <Fragment>
+          <Text
+            style={{ maxWidth: 912, minHeight: 250, padding: '150px 0px' }}
+            variant={'paragraph-md'}
+            color={'tertiary'}
+          >
+            There are no DAOs here
+          </Text>
+
+          <Pagination
+            onNext={handlePageForward}
+            onPrev={handlePageBack}
+            isLast={!hasNextPage}
+            isFirst={!router.query.page}
+          />
+        </Fragment>
       )}
     </Fragment>
   )

--- a/apps/web/src/modules/dao/components/Explore/Explore.tsx
+++ b/apps/web/src/modules/dao/components/Explore/Explore.tsx
@@ -15,9 +15,10 @@ import ExploreToolbar from './ExploreToolbar'
 
 interface ExploreProps extends Partial<ExploreDaosResponse> {
   isLoading: boolean
+  hasNextPage: boolean
 }
 
-export const Explore: React.FC<ExploreProps> = ({ daos, isLoading }) => {
+export const Explore: React.FC<ExploreProps> = ({ daos, hasNextPage, isLoading }) => {
   const router = useRouter()
   const { pathname } = router
   const chain = useChainStore((x) => x.chain)
@@ -48,7 +49,7 @@ export const Explore: React.FC<ExploreProps> = ({ daos, isLoading }) => {
 
   const handlePageForward = React.useCallback(() => {
     // there are more results to be fetched
-    if (!daos?.length)
+    if (!hasNextPage)
       return {
         pathname,
         query: {
@@ -103,7 +104,7 @@ export const Explore: React.FC<ExploreProps> = ({ daos, isLoading }) => {
           <Pagination
             onNext={handlePageForward}
             onPrev={handlePageBack}
-            isLast={!daos?.length}
+            isLast={!hasNextPage}
             isFirst={!router.query.page}
           />
         </Fragment>

--- a/apps/web/src/pages/api/explore.ts
+++ b/apps/web/src/pages/api/explore.ts
@@ -8,7 +8,7 @@ import { Auction_OrderBy } from 'src/data/subgraph/sdk.generated'
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   const limit = 30
   const { page, orderBy, network } = req.query
-  const pageInt = parseInt(page as string, 10)
+  const pageInt = parseInt(page as string, 10) || 1
 
   const chain = PUBLIC_DEFAULT_CHAINS.find((x) => x.slug === network)
 
@@ -16,7 +16,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
 
   const exploreRes = await exploreDaosRequest(
     chain.id,
-    (pageInt + 1) * limit,
+    (pageInt - 1) * limit,
     orderBy as Auction_OrderBy
   )
 

--- a/apps/web/src/pages/explore.tsx
+++ b/apps/web/src/pages/explore.tsx
@@ -33,12 +33,16 @@ const ExplorePage: NextPageWithLayout = () => {
     }
   )
 
-  const { daos } = data || {}
+  const { daos, hasNextPage } = data || {}
 
   return (
     <Flex direction={'column'} align={'center'} mt={'x5'} minH={'100vh'}>
       <Meta title={'Explore'} type={'website'} slug={'/explore'} />
-      <Explore daos={daos} isLoading={!data && !error} />
+      <Explore
+        daos={daos}
+        hasNextPage={hasNextPage || false}
+        isLoading={!data && !error}
+      />
     </Flex>
   )
 }


### PR DESCRIPTION
## Description

Fixes pagination on explore page, and explore api. Updates helper text for when a user is on a page > 1 and no daos are returned.

## Motivation & context

- users were navigating to pages with no daos on the explore page due to pagination being disabled only when no daos were returned and not when daos.length < limit
- pagination on explore api incorrectly assumed pages started at 0

## Code review

- is pagination showing all pages on the explore page
- is pagination disabled at the right times on the explore page

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have done a self-review of my own code
- [x] Any new and existing tests pass locally with my changes
- [x] My changes generate no new warnings (lint warnings, console warnings, etc)
