### PR TITLE
Fix chain dropdown not closing

### DIFF
--- a/apps/web/src/layouts/DefaultLayout/NavMenu.tsx
+++ b/apps/web/src/layouts/DefaultLayout/NavMenu.tsx
@@ -108,6 +108,10 @@ export const NavMenu = () => {
     }
   }, [router])
 
+  React.useEffect(() => {
+    if (activeDropdown !== 'chainMenu') setIsOpenChainMenu(false)
+  }, [activeDropdown, setIsOpenChainMenu])
+
   return (
     <Flex align={'center'} direction={'row'} gap={'x4'}>
       {isChainInitilized && (


### PR DESCRIPTION
## Description

set `isOpenChainMenu` to false when active dropdown is not `chainMenu`

## Motivation & context

fixes #311 

## Code review

- does chain dropdown close when a user selects their profile

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have done a self-review of my own code
- [x] Any new and existing tests pass locally with my changes
- [x] My changes generate no new warnings (lint warnings, console warnings, etc)
