### PR TITLE
Hide recent DAOs when a network has less than 3 DAOs

### DIFF
--- a/apps/web/src/modules/dao/components/DaoFeed/DaoErrorFeed.tsx
+++ b/apps/web/src/modules/dao/components/DaoFeed/DaoErrorFeed.tsx
@@ -1,0 +1,44 @@
+import { Button, Flex, Text } from '@zoralabs/zord'
+import { useRouter } from 'next/router'
+import { Fragment } from 'react'
+
+import { GridContainer } from './DaoFeed'
+import { emptyTile } from './DaoFeed.css'
+
+export const EmptyTile = ({ displayContent }: { displayContent: boolean }) => {
+  const router = useRouter()
+
+  const onClick = () => router.reload()
+
+  return (
+    <Flex
+      backgroundColor="border"
+      direction="column"
+      justify="center"
+      align="center"
+      className={emptyTile}
+    >
+      {displayContent && (
+        <Fragment>
+          <Text fontWeight="display" mb="x1">
+            Error loading DAOs
+          </Text>
+          <Text mb="x2">Please reload the page</Text>
+          <Button onClick={onClick} variant="secondary" size="sm">
+            Reload
+          </Button>
+        </Fragment>
+      )}
+    </Flex>
+  )
+}
+
+export const DaoErrorFeed = () => {
+  return (
+    <GridContainer>
+      {[...Array(3)].map((_, idx) => (
+        <EmptyTile key={idx} displayContent={idx === 1} />
+      ))}
+    </GridContainer>
+  )
+}

--- a/apps/web/src/modules/dao/components/DaoFeed/DaoFeedCard.tsx
+++ b/apps/web/src/modules/dao/components/DaoFeed/DaoFeedCard.tsx
@@ -4,6 +4,7 @@ import { DaoCard } from 'src/modules/dao'
 import { DaoProps } from 'src/pages'
 
 import { useDaoFeedCard } from '../../hooks'
+import { DaoFeedCardSkeleton } from './DaoFeedSkeleton'
 
 interface DaoCardProps {
   dao: DaoProps
@@ -16,7 +17,7 @@ export const DaoFeedCard: React.FC<DaoCardProps> = ({ dao }) => {
   })
 
   if (!tokenUri?.image || !tokenUri?.name) {
-    return null
+    return <DaoFeedCardSkeleton />
   }
 
   return (

--- a/apps/web/src/modules/dao/components/DaoFeed/DaoFeedSkeleton.tsx
+++ b/apps/web/src/modules/dao/components/DaoFeed/DaoFeedSkeleton.tsx
@@ -3,19 +3,25 @@ import { Box } from '@zoralabs/zord'
 import { exploreSkeleton } from '../Explore/Explore.css'
 import { GridContainer } from './DaoFeed'
 
+export const DaoFeedCardSkeleton = ({ key }: { key?: any }) => {
+  return (
+    <Box
+      key={key}
+      borderRadius="curved"
+      backgroundColor="background2"
+      width={'100%'}
+      aspectRatio={1 / 1}
+      position="relative"
+      className={exploreSkeleton}
+    />
+  )
+}
+
 export const DaoFeedSkeleton = () => {
   return (
     <GridContainer>
       {[...Array(3)].map((_, idx) => (
-        <Box
-          key={idx}
-          borderRadius="curved"
-          backgroundColor="background2"
-          width={'100%'}
-          aspectRatio={1 / 1}
-          position="relative"
-          className={exploreSkeleton}
-        />
+        <DaoFeedCardSkeleton key={idx} />
       ))}
     </GridContainer>
   )

--- a/apps/web/src/modules/dao/components/DaoFeed/DaoFeedSkeleton.tsx
+++ b/apps/web/src/modules/dao/components/DaoFeed/DaoFeedSkeleton.tsx
@@ -1,0 +1,22 @@
+import { Box } from '@zoralabs/zord'
+
+import { exploreSkeleton } from '../Explore/Explore.css'
+import { GridContainer } from './DaoFeed'
+
+export const DaoFeedSkeleton = () => {
+  return (
+    <GridContainer>
+      {[...Array(3)].map((_, idx) => (
+        <Box
+          key={idx}
+          borderRadius="curved"
+          backgroundColor="background2"
+          width={'100%'}
+          aspectRatio={1 / 1}
+          position="relative"
+          className={exploreSkeleton}
+        />
+      ))}
+    </GridContainer>
+  )
+}

--- a/apps/web/src/pages/index.tsx
+++ b/apps/web/src/pages/index.tsx
@@ -16,6 +16,7 @@ import { highestBidsRequest } from 'src/data/subgraph/requests/homepageQuery'
 import { AuctionFragment } from 'src/data/subgraph/sdk.generated'
 import { getHomeLayout } from 'src/layouts/HomeLayout'
 import { DaoFeed } from 'src/modules/dao'
+import { DaoFeedSkeleton } from 'src/modules/dao/components/DaoFeed/DaoFeedSkeleton'
 import { useChainStore } from 'src/stores/useChainStore'
 
 import { NextPageWithLayout } from './_app'
@@ -24,11 +25,17 @@ export type DaoProps = AuctionFragment['dao']
 
 const HomePage: NextPageWithLayout = () => {
   const chain = useChainStore((x) => x.chain)
-  const { data: featuredDaos } = useSWR([SWR_KEYS.FEATURED, chain.id], async () => {
-    return process.env.NEXT_PUBLIC_NETWORK_TYPE === 'mainnet'
-      ? await highestBidsRequest(chain.id)
-      : { data: PUBLIC_FEATURED_DAOS[chain.id as TestnetChain], statusCode: 200 }
-  })
+  const { data: featuredDaos, error } = useSWR(
+    [SWR_KEYS.FEATURED, chain.id],
+    async () => {
+      return process.env.NEXT_PUBLIC_NETWORK_TYPE === 'mainnet'
+        ? await highestBidsRequest(chain.id)
+        : { data: PUBLIC_FEATURED_DAOS[chain.id as TestnetChain], statusCode: 200 }
+    }
+  )
+
+  const isLoading = !featuredDaos && !error
+  const hasDaos = featuredDaos?.data.length || 0 > 0
 
   return (
     <>
@@ -37,10 +44,16 @@ const HomePage: NextPageWithLayout = () => {
         <Marquee />
         <GetStarted />
         <VisitAlternate />
-        {featuredDaos && (
+        {isLoading ? (
+          <RecentlyCreated>
+            <DaoFeedSkeleton />
+          </RecentlyCreated>
+        ) : featuredDaos && (featuredDaos.statusCode >= 500 || hasDaos) ? (
           <RecentlyCreated>
             <DaoFeed featuredDaos={featuredDaos.data} error={featuredDaos.statusCode} />
           </RecentlyCreated>
+        ) : (
+          <></>
         )}
         <Everything />
         <FAQ />

--- a/apps/web/src/pages/index.tsx
+++ b/apps/web/src/pages/index.tsx
@@ -1,42 +1,22 @@
 import { Stack } from '@zoralabs/zord'
 import React from 'react'
-import useSWR from 'swr'
 
 import Everything from 'src/components/Home/Everything'
 import FAQ from 'src/components/Home/FAQ'
 import GetStarted from 'src/components/Home/GetStarted'
 import Marquee from 'src/components/Home/Marquee'
-import RecentlyCreated from 'src/components/Home/RecentlyCreated'
 import Twitter from 'src/components/Home/Twitter'
 import VisitAlternate from 'src/components/Home/VisitAlternate'
 import { Meta } from 'src/components/Meta'
-import { PUBLIC_FEATURED_DAOS, TestnetChain } from 'src/constants/featuredDaos'
-import SWR_KEYS from 'src/constants/swrKeys'
-import { highestBidsRequest } from 'src/data/subgraph/requests/homepageQuery'
 import { AuctionFragment } from 'src/data/subgraph/sdk.generated'
 import { getHomeLayout } from 'src/layouts/HomeLayout'
 import { DaoFeed } from 'src/modules/dao'
-import { DaoFeedSkeleton } from 'src/modules/dao/components/DaoFeed/DaoFeedSkeleton'
-import { useChainStore } from 'src/stores/useChainStore'
 
 import { NextPageWithLayout } from './_app'
 
 export type DaoProps = AuctionFragment['dao']
 
 const HomePage: NextPageWithLayout = () => {
-  const chain = useChainStore((x) => x.chain)
-  const { data: featuredDaos, error } = useSWR(
-    [SWR_KEYS.FEATURED, chain.id],
-    async () => {
-      return process.env.NEXT_PUBLIC_NETWORK_TYPE === 'mainnet'
-        ? await highestBidsRequest(chain.id)
-        : { data: PUBLIC_FEATURED_DAOS[chain.id as TestnetChain], statusCode: 200 }
-    }
-  )
-
-  const isLoading = !featuredDaos && !error
-  const hasDaos = featuredDaos?.data.length || 0 > 0
-
   return (
     <>
       <Meta title={'Nouns your ideas'} type={'website'} slug={'/'} />
@@ -44,17 +24,7 @@ const HomePage: NextPageWithLayout = () => {
         <Marquee />
         <GetStarted />
         <VisitAlternate />
-        {isLoading ? (
-          <RecentlyCreated>
-            <DaoFeedSkeleton />
-          </RecentlyCreated>
-        ) : featuredDaos && (featuredDaos.statusCode >= 500 || hasDaos) ? (
-          <RecentlyCreated>
-            <DaoFeed featuredDaos={featuredDaos.data} error={featuredDaos.statusCode} />
-          </RecentlyCreated>
-        ) : (
-          <></>
-        )}
+        <DaoFeed />
         <Everything />
         <FAQ />
         <Twitter />


### PR DESCRIPTION
## Description

- Changes recent daos feed to only show when a dao has at least 3 daos. 
- Adds skeleton loading to recent daos feed

## Motivation & context

- Recent daos component still displays even when a network has no daos

![Screen Shot 2023-07-24 at 3 24 51 PM](https://github.com/ourzora/nouns-builder/assets/33191293/5d896f9a-906f-443f-837f-47b3a6b8aaa8)

## Code review

- does recent daos feed display when a network has > 2 daos
- does recent daos feed hide then a network has < 3 daos
- does new skeleton loading work

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have done a self-review of my own code
- [x] Any new and existing tests pass locally with my changes
- [x] My changes generate no new warnings (lint warnings, console warnings, etc)
