### PR TITLE
No auction section and Activity tab as default

### DIFF
--- a/apps/web/src/pages/dao/[network]/[token]/[tokenId].tsx
+++ b/apps/web/src/pages/dao/[network]/[token]/[tokenId].tsx
@@ -113,7 +113,7 @@ const TokenPage: NextPageWithLayout<TokenPageProps> = ({
   const ogDescription =
     description.length > 111 ? `${description.slice(0, 111)}...` : description
 
-  const activeTab = query?.tab ? (query.tab as string) : 'About'
+  const activeTab = query?.tab ? (query.tab as string) : 'Activity'
 
   return (
     <Flex direction="column" pb="x30">
@@ -124,16 +124,6 @@ const TokenPage: NextPageWithLayout<TokenPageProps> = ({
         slug={url}
         description={ogDescription}
       />
-      {token && addresses?.auction ? (
-        <Auction
-          chain={chain}
-          auctionAddress={addresses.auction}
-          collection={collection}
-          token={token}
-        />
-      ) : (
-        <AuctionSkeleton />
-      )}
       <SectionHandler
         sections={sections}
         activeTab={activeTab}


### PR DESCRIPTION
## Description

Do not display the auction section on the Dao page.

## Motivation & context

Required for using the site as proposals view embedding in Builder mobile app. With auctions, it doesn't pass App Store Review.