### PR TITLE
Change bid history to use subgraph

### DIFF
--- a/apps/web/src/data/subgraph/fragments/AuctionBid.graphql
+++ b/apps/web/src/data/subgraph/fragments/AuctionBid.graphql
@@ -1,0 +1,5 @@
+fragment AuctionBid on AuctionBid {
+  id
+  amount
+  bidder
+}

--- a/apps/web/src/data/subgraph/queries/auctionBids.graphql
+++ b/apps/web/src/data/subgraph/queries/auctionBids.graphql
@@ -1,0 +1,7 @@
+query auctionBids($id: ID!) {
+  auction(id: $id) {
+    bids(orderBy: bidTime, orderDirection: desc) {
+      ...AuctionBid
+    }
+  }
+}

--- a/apps/web/src/data/subgraph/sdk.generated.ts
+++ b/apps/web/src/data/subgraph/sdk.generated.ts
@@ -1848,6 +1848,13 @@ export type AuctionFragment = {
   dao: { __typename?: 'DAO'; name: string; auctionAddress: any; tokenAddress: any }
 }
 
+export type AuctionBidFragment = {
+  __typename?: 'AuctionBid'
+  id: string
+  amount: any
+  bidder: any
+}
+
 export type DaoFragment = {
   __typename?: 'DAO'
   name: string
@@ -1918,6 +1925,23 @@ export type ActiveAuctionsQuery = {
     __typename?: 'Auction'
     dao: { __typename?: 'DAO'; name: string; auctionAddress: any; tokenAddress: any }
   }>
+}
+
+export type AuctionBidsQueryVariables = Exact<{
+  id: Scalars['ID']
+}>
+
+export type AuctionBidsQuery = {
+  __typename?: 'Query'
+  auction?: {
+    __typename?: 'Auction'
+    bids?: Array<{
+      __typename?: 'AuctionBid'
+      id: string
+      amount: any
+      bidder: any
+    }> | null
+  } | null
 }
 
 export type DaoInfoQueryVariables = Exact<{
@@ -2150,6 +2174,13 @@ export const AuctionFragmentDoc = gql`
     }
   }
 `
+export const AuctionBidFragmentDoc = gql`
+  fragment AuctionBid on AuctionBid {
+    id
+    amount
+    bidder
+  }
+`
 export const DaoFragmentDoc = gql`
   fragment DAO on DAO {
     name
@@ -2237,6 +2268,16 @@ export const ActiveAuctionsDocument = gql`
     }
   }
   ${AuctionFragmentDoc}
+`
+export const AuctionBidsDocument = gql`
+  query auctionBids($id: ID!) {
+    auction(id: $id) {
+      bids(orderBy: bidTime, orderDirection: desc) {
+        ...AuctionBid
+      }
+    }
+  }
+  ${AuctionBidFragmentDoc}
 `
 export const DaoInfoDocument = gql`
   query daoInfo($tokenAddress: ID!) {
@@ -2415,6 +2456,20 @@ export function getSdk(
             ...wrappedRequestHeaders,
           }),
         'activeAuctions',
+        'query'
+      )
+    },
+    auctionBids(
+      variables: AuctionBidsQueryVariables,
+      requestHeaders?: Dom.RequestInit['headers']
+    ): Promise<AuctionBidsQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<AuctionBidsQuery>(AuctionBidsDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'auctionBids',
         'query'
       )
     },

--- a/apps/web/src/modules/auction/components/AllBids/AllBids.tsx
+++ b/apps/web/src/modules/auction/components/AllBids/AllBids.tsx
@@ -1,10 +1,12 @@
 import { Box, Flex } from '@zoralabs/zord'
 import React from 'react'
 
-import { Bid, BidCard } from './BidCard'
+import { AuctionBidFragment } from 'src/data/subgraph/sdk.generated'
+
+import { BidCard } from './BidCard'
 
 interface AuctionAllBidsProps {
-  bids: Bid[]
+  bids: AuctionBidFragment[]
 }
 
 export const AllBids: React.FC<AuctionAllBidsProps> = ({ bids }) => {
@@ -17,7 +19,7 @@ export const AllBids: React.FC<AuctionAllBidsProps> = ({ bids }) => {
           </Box>
 
           <Flex pb="x4" direction="column" overflowY="auto" style={{ height: 200 }}>
-            {bids.map((bid: Bid) => (
+            {bids.map((bid: AuctionBidFragment) => (
               <BidCard key={`${bid.bidder}_${bid.amount}_expanded`} bid={bid} />
             ))}
           </Flex>

--- a/apps/web/src/modules/auction/components/AllBids/BidCard.tsx
+++ b/apps/web/src/modules/auction/components/AllBids/BidCard.tsx
@@ -4,18 +4,12 @@ import React from 'react'
 import { Avatar } from 'src/components/Avatar'
 import { Icon } from 'src/components/Icon'
 import { ETHERSCAN_BASE_URL } from 'src/constants/etherscan'
+import { AuctionBidFragment } from 'src/data/subgraph/sdk.generated'
 import { useEnsData } from 'src/hooks/useEnsData'
 import { useChainStore } from 'src/stores/useChainStore'
 import { formatCryptoVal } from 'src/utils/numbers'
 
-export interface Bid {
-  id: string | number
-  bidder: string
-  amount: string
-  transactionHash: string
-}
-
-export const BidCard = ({ bid }: { bid: Bid }) => {
+export const BidCard = ({ bid }: { bid: AuctionBidFragment }) => {
   const { displayName, ensAvatar } = useEnsData(bid?.bidder)
   const chain = useChainStore((x) => x.chain)
 
@@ -31,7 +25,7 @@ export const BidCard = ({ bid }: { bid: Bid }) => {
         <Flex direction="row" align="center">
           <Flex
             as="a"
-            href={`${ETHERSCAN_BASE_URL[chain.id]}/tx/${bid.transactionHash}`}
+            href={`${ETHERSCAN_BASE_URL[chain.id]}/address/${bid.bidder}`}
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/apps/web/src/modules/auction/components/Auction.tsx
+++ b/apps/web/src/modules/auction/components/Auction.tsx
@@ -1,12 +1,14 @@
 import { readContract } from '@wagmi/core'
 import { Flex, Grid } from '@zoralabs/zord'
+import { formatEther } from 'ethers/lib/utils.js'
 import React, { Fragment } from 'react'
 import useSWR from 'swr'
 
 import SWR_KEYS from 'src/constants/swrKeys'
 import { auctionAbi } from 'src/data/contract/abis'
-import getBids from 'src/data/contract/requests/getBids'
 import { TokenWithWinner } from 'src/data/contract/requests/getToken'
+import { SDK } from 'src/data/subgraph/client'
+import { AuctionBidFragment } from 'src/data/subgraph/sdk.generated'
 import { AddressType, Chain } from 'src/typings'
 
 import { useAuctionEvents } from '../hooks'
@@ -59,7 +61,15 @@ export const Auction: React.FC<AuctionControllerProps> = ({
 
   const { data: bids } = useSWR(
     [SWR_KEYS.AUCTION_BIDS, chain.id, auctionAddress, token.id],
-    () => getBids(chain.id, auctionAddress, token.id)
+    () =>
+      SDK.connect(chain.id)
+        .auctionBids({ id: `${collection.toLowerCase()}:${token.id}` })
+        .then((x) =>
+          x.auction?.bids?.map((bid: AuctionBidFragment) => ({
+            ...bid,
+            amount: formatEther(bid.amount),
+          }))
+        )
   )
 
   return (

--- a/apps/web/src/modules/auction/components/BidHistory.tsx
+++ b/apps/web/src/modules/auction/components/BidHistory.tsx
@@ -2,7 +2,7 @@ import { Button, Flex } from '@zoralabs/zord'
 import dynamic from 'next/dynamic'
 import { ReactNode } from 'react'
 
-import { Bid } from 'src/data/contract/requests/getBids'
+import { AuctionBidFragment } from 'src/data/subgraph/sdk.generated'
 
 import { AllBids } from './AllBids'
 
@@ -10,7 +10,7 @@ const AnimatedModal = dynamic(() => import('src/components/Modal/AnimatedModal')
   ssr: false,
 })
 
-export const BidHistory = ({ bids }: { bids: Bid[] }) => {
+export const BidHistory = ({ bids }: { bids: AuctionBidFragment[] }) => {
   return (
     <AnimatedModal
       trigger={

--- a/apps/web/src/modules/auction/components/CurrentAuction/CurrentAuction.tsx
+++ b/apps/web/src/modules/auction/components/CurrentAuction/CurrentAuction.tsx
@@ -2,7 +2,7 @@ import dayjs from 'dayjs'
 import { BigNumber, ethers } from 'ethers'
 import React, { Fragment, useState } from 'react'
 
-import { Bid } from 'src/data/contract/requests/getBids'
+import { AuctionBidFragment } from 'src/data/subgraph/sdk.generated'
 import { useTimeout } from 'src/hooks/useTimeout'
 import { Chain } from 'src/typings'
 
@@ -29,7 +29,7 @@ export const CurrentAuction = ({
   bid?: BigNumber
   owner?: string
   endTime?: number
-  bids: Bid[]
+  bids: AuctionBidFragment[]
 }) => {
   const [isEnded, setIsEnded] = useState(false)
   const [isEnding, setIsEnding] = useState(false)

--- a/apps/web/src/modules/auction/components/CurrentAuction/RecentBids.tsx
+++ b/apps/web/src/modules/auction/components/CurrentAuction/RecentBids.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 
 import { Icon } from 'src/components/Icon'
 import { ETHERSCAN_BASE_URL } from 'src/constants/etherscan'
-import { Bid } from 'src/data/contract/requests/getBids'
+import { AuctionBidFragment } from 'src/data/subgraph/sdk.generated'
 import { useChainStore } from 'src/stores/useChainStore'
 
 import { AllBids } from '../AllBids'
@@ -16,7 +16,7 @@ const AnimatedModal = dynamic(() => import('src/components/Modal/AnimatedModal')
 })
 
 interface RecentBidsProps {
-  bids: Bid[]
+  bids: AuctionBidFragment[]
 }
 
 export const RecentBids: React.FC<RecentBidsProps> = ({ bids }) => {
@@ -25,7 +25,7 @@ export const RecentBids: React.FC<RecentBidsProps> = ({ bids }) => {
   return bids.length ? (
     <Box mt="x3">
       <Stack>
-        {bids.slice(0, 3).map(({ amount, bidder, id, transactionHash }) => (
+        {bids.slice(0, 3).map(({ amount, bidder, id }) => (
           <Flex
             align="center"
             py="x2"
@@ -38,7 +38,7 @@ export const RecentBids: React.FC<RecentBidsProps> = ({ bids }) => {
             <Flex
               align="center"
               as="a"
-              href={`${ETHERSCAN_BASE_URL[chain.id]}/tx/${transactionHash}`}
+              href={`${ETHERSCAN_BASE_URL[chain.id]}/address/${bidder}`}
               target="_blank"
               rel="noopener noreferrer"
             >


### PR DESCRIPTION
## Description

Updates bid history to use subgraph

## Motivation & context

- fixes bid history issues when rpc does not support `getLogs` calls
- fetches bid history faster

## Code review

- do auction bids fetch correctly

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have done a self-review of my own code
- [x] Any new and existing tests pass locally with my changes
- [x] My changes generate no new warnings (lint warnings, console warnings, etc)
