### PR TITLE
Add proper validation for L2 ens names

### DIFF
--- a/apps/web/src/modules/create-dao/components/AllocationForm/AllocationForm.schema.ts
+++ b/apps/web/src/modules/create-dao/components/AllocationForm/AllocationForm.schema.ts
@@ -1,30 +1,9 @@
-import { debounce } from 'lodash'
 import * as Yup from 'yup'
 
-import { CHAIN_ID } from 'src/typings'
-import { isValidAddress } from 'src/utils/ens'
-import { getProvider } from 'src/utils/provider'
-
-const validateAddress = async (
-  value: string | undefined,
-  res: (value: boolean | PromiseLike<boolean>) => void
-) => {
-  try {
-    res(!!value && (await isValidAddress(value, getProvider(CHAIN_ID.ETHEREUM))))
-  } catch (err) {
-    res(false)
-  }
-}
-
-export const deboucedValidateAddress = async (value: string | undefined) => {
-  const debouncedFn = debounce(validateAddress, 500)
-  return await new Promise<boolean>((res) => debouncedFn(value, res))
-}
+import { addressValidationSchema } from 'src/utils/yup'
 
 export const allocationSchema = Yup.object().shape({
-  founderAddress: Yup.string()
-    .test('isValidAddress', 'invalid address', deboucedValidateAddress)
-    .required('*'),
+  founderAddress: addressValidationSchema,
   allocationPercentage: Yup.number()
     .transform((value) => (isNaN(value) ? undefined : value))
     .required('*')

--- a/apps/web/src/modules/create-dao/components/VetoForm.tsx
+++ b/apps/web/src/modules/create-dao/components/VetoForm.tsx
@@ -13,9 +13,9 @@ import {
 import { Icon } from 'src/components/Icon'
 import { getEnsAddress } from 'src/utils/ens'
 import { isEmpty } from 'src/utils/helpers'
+import { addressValidationSchema } from 'src/utils/yup'
 
 import { useFormStore } from '../stores'
-import { deboucedValidateAddress } from './AllocationForm/AllocationForm.schema'
 
 interface VetoFormProps {
   title: string
@@ -39,9 +39,7 @@ export const vetoValidationSchema = Yup.object().shape({
   vetoPower: Yup.boolean().required(),
   vetoerAddress: Yup.string().when('vetoPower', {
     is: true,
-    then: Yup.string()
-      .required('*')
-      .test('isValidAddress', 'invalid address', deboucedValidateAddress),
+    then: addressValidationSchema,
   }),
 })
 

--- a/apps/web/src/modules/create-proposal/components/TransactionForm/Airdrop/AirdropForm.schema.ts
+++ b/apps/web/src/modules/create-proposal/components/TransactionForm/Airdrop/AirdropForm.schema.ts
@@ -1,7 +1,7 @@
 import * as yup from 'yup'
 
 import type { AddressType } from 'src/typings'
-import { isValidAddress } from 'src/utils/ens'
+import { addressValidationSchema } from 'src/utils/yup'
 
 export interface AirdropFormValues {
   recipientAddress?: string | AddressType
@@ -9,19 +9,7 @@ export interface AirdropFormValues {
 }
 
 const airdropFormSchema = yup.object({
-  recipientAddress: yup
-    .string()
-    .strip()
-    .test(
-      'is-valid-address-or-ens',
-      'This address or ENS domain is not valid',
-      async (
-        _,
-        ctx: yup.TestContext<AirdropFormValues> & {
-          originalValue?: string
-        }
-      ) => await isValidAddress(ctx?.originalValue as string)
-    ),
+  recipientAddress: addressValidationSchema,
   amount: yup.number().min(1, 'Must be at least 1 token').required(),
 })
 

--- a/apps/web/src/modules/create-proposal/components/TransactionForm/CustomTransaction/forms/Address/Address.tsx
+++ b/apps/web/src/modules/create-proposal/components/TransactionForm/CustomTransaction/forms/Address/Address.tsx
@@ -7,7 +7,6 @@ import {
   initCustomTransaction,
   useCustomTransactionStore,
 } from 'src/modules/create-proposal'
-import { useLayoutStore } from 'src/stores'
 import { useChainStore } from 'src/stores/useChainStore'
 
 import { CustomTransactionForm } from '../CustomTransactionForm'
@@ -15,7 +14,6 @@ import { contractAddressFields, validateContractAddress } from './fields'
 
 export const Address = () => {
   const { customTransaction, composeCustomTransaction } = useCustomTransactionStore()
-  const { provider } = useLayoutStore()
   const chain = useChainStore((x) => x.chain)
   const initialValues = {
     transactionContractAddress: customTransaction?.address || '',
@@ -55,7 +53,7 @@ export const Address = () => {
       <CustomTransactionForm
         initialValues={initialValues}
         fields={contractAddressFields}
-        validationSchema={validateContractAddress(provider)}
+        validationSchema={validateContractAddress}
         submitCallback={(values) => submitCallback(values)}
       />
     </Flex>

--- a/apps/web/src/modules/create-proposal/components/TransactionForm/CustomTransaction/forms/Address/fields.ts
+++ b/apps/web/src/modules/create-proposal/components/TransactionForm/CustomTransaction/forms/Address/fields.ts
@@ -1,8 +1,7 @@
-import { Provider } from '@ethersproject/abstract-provider'
 import * as Yup from 'yup'
 
 import { TEXT } from 'src/components/Fields/types'
-import { isValidAddress } from 'src/utils/ens'
+import { addressValidationSchema } from 'src/utils/yup'
 
 export const contractAddressFields = [
   {
@@ -15,13 +14,6 @@ export const contractAddressFields = [
   },
 ]
 
-export const validateContractAddress = (provider: Provider | undefined) =>
-  Yup.object().shape({
-    transactionContractAddress: Yup.string()
-      .test(
-        'isValidAddress',
-        'invalid address',
-        (value: string | undefined) => !!value && isValidAddress(value, provider)
-      )
-      .required('*'),
-  })
+export const validateContractAddress = Yup.object().shape({
+  transactionContractAddress: addressValidationSchema,
+})

--- a/apps/web/src/modules/create-proposal/components/TransactionForm/Droposal/DroposalForm.schema.ts
+++ b/apps/web/src/modules/create-proposal/components/TransactionForm/Droposal/DroposalForm.schema.ts
@@ -1,6 +1,6 @@
 import * as yup from 'yup'
 
-import { deboucedValidateAddress } from 'src/modules/create-dao/components/AllocationForm/AllocationForm.schema'
+import { addressValidationSchema } from 'src/utils/yup'
 
 export interface DroposalFormValues {
   name: string
@@ -30,14 +30,8 @@ const droposalFormSchema = yup.object({
   maxPerAddress: yup.number().integer('Must be whole number'),
   maxSupply: yup.number().required('*').integer('Must be whole number'),
   royaltyPercentage: yup.number().required('*'),
-  defaultAdmin: yup
-    .string()
-    .required('*')
-    .test('isValidAddress', 'invalid address', deboucedValidateAddress),
-  fundsRecipient: yup
-    .string()
-    .required('*')
-    .test('isValidAddress', 'invalid address', deboucedValidateAddress),
+  defaultAdmin: addressValidationSchema,
+  fundsRecipient: addressValidationSchema,
   publicSaleStart: yup.string().required('*'),
   publicSaleEnd: yup
     .string()

--- a/apps/web/src/modules/create-proposal/components/TransactionForm/SendEth/SendEth.schema.ts
+++ b/apps/web/src/modules/create-proposal/components/TransactionForm/SendEth/SendEth.schema.ts
@@ -1,7 +1,7 @@
 import * as yup from 'yup'
 
 import type { AddressType } from 'src/typings'
-import { isValidAddress } from 'src/utils/ens'
+import { addressValidationSchema } from 'src/utils/yup'
 
 export interface SendEthValues {
   recipientAddress?: string | AddressType
@@ -10,19 +10,7 @@ export interface SendEthValues {
 
 const sendEthSchema = (treasuryBalance: number) =>
   yup.object({
-    recipientAddress: yup
-      .string()
-      .strip()
-      .test(
-        'is-valid-address-or-ens',
-        'This address or ENS domain is not valid',
-        async (
-          _,
-          ctx: yup.TestContext<SendEthValues> & {
-            originalValue?: string
-          }
-        ) => await isValidAddress(ctx?.originalValue as string)
-      ),
+    recipientAddress: addressValidationSchema,
     amount: yup
       .number()
       .required()

--- a/apps/web/src/modules/dao/components/Activity/DelegateForm.schema.ts
+++ b/apps/web/src/modules/dao/components/Activity/DelegateForm.schema.ts
@@ -1,15 +1,7 @@
-import { Provider } from '@ethersproject/abstract-provider'
 import * as Yup from 'yup'
 
-import { isValidAddress } from 'src/utils/ens'
+import { addressValidationSchema } from 'src/utils/yup'
 
-export const delegateValidationSchema = (provider: Provider | undefined) =>
-  Yup.object().shape({
-    address: Yup.string()
-      .test(
-        'isValidAddress',
-        'invalid address',
-        (value: string | undefined) => !!value && isValidAddress(value, provider)
-      )
-      .required('*'),
-  })
+export const delegateValidationSchema = Yup.object().shape({
+  address: addressValidationSchema,
+})

--- a/apps/web/src/modules/dao/components/Activity/DelegateForm.tsx
+++ b/apps/web/src/modules/dao/components/Activity/DelegateForm.tsx
@@ -76,7 +76,7 @@ export const DelegateForm = ({ handleBack, handleUpdate }: DelegateFormProps) =>
       <Formik
         initialValues={{ address: '' }}
         onSubmit={submitCallback}
-        validationSchema={delegateValidationSchema(provider)}
+        validationSchema={delegateValidationSchema}
       >
         {({ isValid, dirty, values }) => (
           <FormikForm>

--- a/apps/web/src/modules/dao/components/AdminForm/AdminForm.schema.ts
+++ b/apps/web/src/modules/dao/components/AdminForm/AdminForm.schema.ts
@@ -4,8 +4,11 @@ import * as Yup from 'yup'
 import { TokenAllocation, auctionSettingsValidationSchema } from 'src/modules/create-dao'
 import { allocationSchema } from 'src/modules/create-dao/components/AllocationForm/AllocationForm.schema'
 import { Duration } from 'src/typings'
-import { isValidAddress } from 'src/utils/ens'
-import { durationValidationSchema, urlValidationSchema } from 'src/utils/yup'
+import {
+  addressValidationSchema,
+  durationValidationSchema,
+  urlValidationSchema,
+} from 'src/utils/yup'
 
 export interface AdminFormValues {
   daoAvatar: string
@@ -35,13 +38,7 @@ export const adminValidationSchema = (provider: Provider | undefined) =>
         projectDescription: Yup.string().required('*').max(5000, '< 5000 characters'),
         daoWebsite: urlValidationSchema,
         rendererBaseUrl: urlValidationSchema,
-        vetoer: Yup.string()
-          .test(
-            'isValidAddress',
-            'invalid address',
-            (value: string | undefined) => !!value && isValidAddress(value, provider)
-          )
-          .required('*'),
+        vetoer: addressValidationSchema,
         votingDelay: durationValidationSchema(
           { value: 1, description: '1 second' },
           { value: twentyFourWeeks, description: '24 weeks' }

--- a/apps/web/src/stores/useChainStore.tsx
+++ b/apps/web/src/stores/useChainStore.tsx
@@ -9,6 +9,8 @@ export interface ChainStoreProps {
   setChain: (chain: Chain) => void
 }
 
+export const CHAIN_STORE_IDENTIFIER = `nouns-builder-chain-${process.env.NEXT_PUBLIC_NETWORK_TYPE}`
+
 export const useChainStore = create(
   persist<ChainStoreProps>(
     (set) => ({
@@ -16,7 +18,7 @@ export const useChainStore = create(
       setChain: (chain) => set({ chain }),
     }),
     {
-      name: `nouns-builder-chain-${process.env.NEXT_PUBLIC_NETWORK_TYPE}`,
+      name: CHAIN_STORE_IDENTIFIER,
       storage: createJSONStorage(() => localStorage),
       version: 0,
     }

--- a/apps/web/src/utils/ens.ts
+++ b/apps/web/src/utils/ens.ts
@@ -3,20 +3,48 @@ import { ethers } from 'ethers'
 
 import { RPC_URL } from 'src/constants/rpc'
 import { CHAIN_ID } from 'src/typings'
+import { getChainFromLocalStorage } from 'src/utils/getChainFromLocalStorage'
 
 const defaultProvider: Provider = new ethers.providers.JsonRpcProvider(
   RPC_URL[CHAIN_ID.ETHEREUM]
 )
 
+export type IsValidAddressResult = {
+  data: boolean
+  error?: string
+}
+
 export async function isValidAddress(
   address: string,
   provider: Provider | undefined = defaultProvider
-) {
+): Promise<IsValidAddressResult> {
   try {
-    const resolvedName = await provider?.resolveName(address)
-    return !!resolvedName || ethers.utils.isAddress(address)
+    if (ethers.utils.isAddress(address)) return { data: true }
+
+    const { id: chainId } = getChainFromLocalStorage()
+
+    let resolvedName: string | null
+
+    if (chainId === CHAIN_ID.ETHEREUM || chainId === CHAIN_ID.GOERLI) {
+      resolvedName = await provider?.resolveName(address)
+    } else {
+      const [nameResponse, codeResponse] = await Promise.all([
+        provider?.resolveName(address),
+        provider?.getCode(address),
+      ])
+
+      if (codeResponse !== '0x')
+        return { data: false, error: 'ENS for contracts is not supported on L2' }
+
+      resolvedName = nameResponse
+    }
+
+    return {
+      data: !!resolvedName,
+      error: resolvedName ? undefined : 'Invalid address',
+    }
   } catch {
-    return false
+    return { data: false, error: 'Invalid address' }
   }
 }
 

--- a/apps/web/src/utils/getChainFromLocalStorage.ts
+++ b/apps/web/src/utils/getChainFromLocalStorage.ts
@@ -1,0 +1,8 @@
+import { PUBLIC_DEFAULT_CHAINS } from 'src/constants/defaultChains'
+import { CHAIN_STORE_IDENTIFIER } from 'src/stores/useChainStore'
+import { Chain } from 'src/typings'
+
+export const getChainFromLocalStorage = (): Chain => {
+  const rawChain = localStorage.getItem(CHAIN_STORE_IDENTIFIER)
+  return rawChain ? JSON.parse(rawChain)?.state?.chain : PUBLIC_DEFAULT_CHAINS[0]
+}

--- a/apps/web/src/utils/yup/address.schema.ts
+++ b/apps/web/src/utils/yup/address.schema.ts
@@ -1,0 +1,38 @@
+import { debounce } from 'lodash'
+import * as Yup from 'yup'
+
+import { CHAIN_ID } from 'src/typings'
+import { isValidAddress } from 'src/utils/ens'
+import { getProvider } from 'src/utils/provider'
+
+const validateAddress = async (
+  value: string | undefined,
+  ctx: Yup.TestContext<any>,
+  res: (value: boolean | Yup.ValidationError) => void
+) => {
+  try {
+    if (!value) return res(false)
+    const { data: isValid, error } = await isValidAddress(
+      value,
+      getProvider(CHAIN_ID.ETHEREUM)
+    )
+    if (error) return res(ctx.createError({ message: error, path: ctx.path }))
+    res(isValid)
+  } catch (err) {
+    res(false)
+  }
+}
+
+const deboucedValidateAddress = async (
+  value: string | undefined,
+  ctx: Yup.TestContext<any>
+) => {
+  const debouncedFn = debounce(validateAddress, 500)
+  return await new Promise<boolean | Yup.ValidationError>((res) =>
+    debouncedFn(value, ctx, res)
+  )
+}
+
+export const addressValidationSchema = Yup.string()
+  .required('*')
+  .test(deboucedValidateAddress)

--- a/apps/web/src/utils/yup/index.ts
+++ b/apps/web/src/utils/yup/index.ts
@@ -1,2 +1,3 @@
 export * from './duration.schema'
 export * from './url.schema'
+export * from './address.schema'


### PR DESCRIPTION
## Description

- create a shared address validation schema `address.schema.ts`
- updates `isValidAddress` to return a value and an error
- updates `isValidAddress` to prevent users from using ENS names resolving to contracts on L2 (these contracts are not guaranteed to exist on the same address)

## Motivation & context

- prevent users from adding incorrect addresses as founders / recipients 

## Code review

- do addresses inputs validate L2 ens names properly (EOAs should work, smart contracts should not, plain addresses should work)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have done a self-review of my own code
- [x] Any new and existing tests pass locally with my changes
- [x] My changes generate no new warnings (lint warnings, console warnings, etc)
