### PR TITLE
Add filter for spam daos on L2

### DIFF
--- a/apps/web/src/data/subgraph/queries/activeAuctions.graphql
+++ b/apps/web/src/data/subgraph/queries/activeAuctions.graphql
@@ -1,9 +1,9 @@
-query activeAuctions($endTime: BigInt!) {
+query activeAuctions($first: Int!, $where: Auction_filter!) {
   auctions(
     orderBy: highestBid__amount
     orderDirection: desc
-    first: 3
-    where: { bidCount_gt: 0, settled: false, endTime_gt: $endTime }
+    first: $first
+    where: $where
   ) {
     ...Auction
   }

--- a/apps/web/src/data/subgraph/queries/activeDaos.graphql
+++ b/apps/web/src/data/subgraph/queries/activeDaos.graphql
@@ -1,0 +1,5 @@
+query activeDaos($first: Int!) {
+  daos(first: $first, where: { totalAuctionSales_gt: 1000000000000000 }) {
+    id
+  }
+}

--- a/apps/web/src/data/subgraph/queries/activeDaos.graphql
+++ b/apps/web/src/data/subgraph/queries/activeDaos.graphql
@@ -1,5 +1,5 @@
-query activeDaos($first: Int!) {
-  daos(first: $first, where: { totalAuctionSales_gt: 1000000000000000 }) {
+query activeDaos($first: Int!, $where: DAO_filter!) {
+  daos(first: $first, where: $where) {
     id
   }
 }

--- a/apps/web/src/data/subgraph/requests/exploreQueries.ts
+++ b/apps/web/src/data/subgraph/requests/exploreQueries.ts
@@ -46,11 +46,26 @@ export const exploreDaosRequest = async (
       settled: false,
     }
 
+    const first = 30
+
+    // filter spam daos from L2
+    if (
+      chainId === CHAIN_ID.BASE ||
+      chainId === CHAIN_ID.ZORA ||
+      chainId === CHAIN_ID.OPTIMISM
+    ) {
+      const activeDaos = await SDK.connect(chainId).activeDaos({
+        first,
+      })
+
+      // If we have less than 30 active daos, we apply the filter
+      if (activeDaos.daos.length !== first)
+        where.dao_in = activeDaos.daos.map((x) => x.id)
+    }
+
     if (orderBy === Auction_OrderBy.HighestBidAmount) where.bidCount_gt = 0
     if (orderBy === Auction_OrderBy.EndTime)
       where.endTime_gt = Math.floor(Date.now() / 1000)
-
-    const first = 30
 
     const data = await SDK.connect(chainId).exploreDaosPage({
       orderBy,

--- a/apps/web/src/data/subgraph/requests/exploreQueries.ts
+++ b/apps/web/src/data/subgraph/requests/exploreQueries.ts
@@ -56,9 +56,10 @@ export const exploreDaosRequest = async (
     ) {
       const activeDaos = await SDK.connect(chainId).activeDaos({
         first,
+        where: { totalAuctionSales_gt: 1000000000000000 },
       })
 
-      // If we have less than 30 active daos, we apply the filter
+      // If we have less than one explore page of active daos, we apply the filter
       if (activeDaos.daos.length !== first)
         where.dao_in = activeDaos.daos.map((x) => x.id)
     }

--- a/apps/web/src/data/subgraph/requests/homepageQuery.ts
+++ b/apps/web/src/data/subgraph/requests/homepageQuery.ts
@@ -4,6 +4,8 @@ import { SDK } from 'src/data/subgraph/client'
 import { DaoProps } from 'src/pages'
 import { CHAIN_ID } from 'src/typings'
 
+import { Auction_Filter } from '../sdk.generated'
+
 export const highestBidsRequest = async (
   chainId: CHAIN_ID
 ): Promise<{
@@ -14,8 +16,31 @@ export const highestBidsRequest = async (
   let statusCode = null
 
   try {
+    const where: Auction_Filter = {
+      bidCount_gt: 0,
+      settled: false,
+      endTime_gt: Math.floor(Date.now() / 1000),
+    }
+
+    // filter spam daos from L2
+    if (
+      chainId === CHAIN_ID.BASE ||
+      chainId === CHAIN_ID.ZORA ||
+      chainId === CHAIN_ID.OPTIMISM
+    ) {
+      const first = 30
+      const activeDaos = await SDK.connect(chainId).activeDaos({
+        first,
+      })
+
+      // If we have less than 30 active daos, we apply the filter
+      if (activeDaos.daos.length !== first)
+        where.dao_in = activeDaos.daos.map((x) => x.id)
+    }
+
     const data = await SDK.connect(chainId).activeAuctions({
-      endTime: Math.floor(Date.now() / 1000),
+      first: 3,
+      where,
     })
     daos = data?.auctions.map((auction) => auction.dao)
   } catch (e: any) {

--- a/apps/web/src/data/subgraph/requests/homepageQuery.ts
+++ b/apps/web/src/data/subgraph/requests/homepageQuery.ts
@@ -31,9 +31,10 @@ export const highestBidsRequest = async (
       const first = 30
       const activeDaos = await SDK.connect(chainId).activeDaos({
         first,
+        where: { totalAuctionSales_gt: 1000000000000000 },
       })
 
-      // If we have less than 30 active daos, we apply the filter
+      // If we have less than one explore page of active daos, we apply the filter
       if (activeDaos.daos.length !== first)
         where.dao_in = activeDaos.daos.map((x) => x.id)
     }

--- a/apps/web/src/data/subgraph/sdk.generated.ts
+++ b/apps/web/src/data/subgraph/sdk.generated.ts
@@ -1916,7 +1916,8 @@ export type TokenFragment = {
 }
 
 export type ActiveAuctionsQueryVariables = Exact<{
-  endTime: Scalars['BigInt']
+  first: Scalars['Int']
+  where: Auction_Filter
 }>
 
 export type ActiveAuctionsQuery = {
@@ -2330,12 +2331,12 @@ export const TokenFragmentDoc = gql`
   }
 `
 export const ActiveAuctionsDocument = gql`
-  query activeAuctions($endTime: BigInt!) {
+  query activeAuctions($first: Int!, $where: Auction_filter!) {
     auctions(
       orderBy: highestBid__amount
       orderDirection: desc
-      first: 3
-      where: { bidCount_gt: 0, settled: false, endTime_gt: $endTime }
+      first: $first
+      where: $where
     ) {
       ...Auction
     }

--- a/apps/web/src/data/subgraph/sdk.generated.ts
+++ b/apps/web/src/data/subgraph/sdk.generated.ts
@@ -1927,6 +1927,15 @@ export type ActiveAuctionsQuery = {
   }>
 }
 
+export type ActiveDaosQueryVariables = Exact<{
+  first: Scalars['Int']
+}>
+
+export type ActiveDaosQuery = {
+  __typename?: 'Query'
+  daos: Array<{ __typename?: 'DAO'; id: string }>
+}
+
 export type AuctionBidsQueryVariables = Exact<{
   id: Scalars['ID']
 }>
@@ -2333,6 +2342,13 @@ export const ActiveAuctionsDocument = gql`
   }
   ${AuctionFragmentDoc}
 `
+export const ActiveDaosDocument = gql`
+  query activeDaos($first: Int!) {
+    daos(first: $first, where: { totalAuctionSales_gt: 1000000000000000 }) {
+      id
+    }
+  }
+`
 export const AuctionBidsDocument = gql`
   query auctionBids($id: ID!) {
     auction(id: $id) {
@@ -2554,6 +2570,20 @@ export function getSdk(
             ...wrappedRequestHeaders,
           }),
         'activeAuctions',
+        'query'
+      )
+    },
+    activeDaos(
+      variables: ActiveDaosQueryVariables,
+      requestHeaders?: Dom.RequestInit['headers']
+    ): Promise<ActiveDaosQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<ActiveDaosQuery>(ActiveDaosDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'activeDaos',
         'query'
       )
     },

--- a/apps/web/src/data/subgraph/sdk.generated.ts
+++ b/apps/web/src/data/subgraph/sdk.generated.ts
@@ -1930,6 +1930,7 @@ export type ActiveAuctionsQuery = {
 
 export type ActiveDaosQueryVariables = Exact<{
   first: Scalars['Int']
+  where: Dao_Filter
 }>
 
 export type ActiveDaosQuery = {
@@ -2344,8 +2345,8 @@ export const ActiveAuctionsDocument = gql`
   ${AuctionFragmentDoc}
 `
 export const ActiveDaosDocument = gql`
-  query activeDaos($first: Int!) {
-    daos(first: $first, where: { totalAuctionSales_gt: 1000000000000000 }) {
+  query activeDaos($first: Int!, $where: DAO_filter!) {
+    daos(first: $first, where: $where) {
       id
     }
   }


### PR DESCRIPTION
## Description

- filters daos with total auction amount less than 0.001 ETH on L2
- ideally this would only take 1 query to filter and pull dao data instead of 2 but this will be a temp measure until we can rework the explore page.

## Motivation & context

- l2 networks are getting spammed with airdrop farmers

## Code review

- are daos with less than 0.001 ETH total auction sales filtered on L2


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have done a self-review of my own code
- [x] Any new and existing tests pass locally with my changes
- [x] My changes generate no new warnings (lint warnings, console warnings, etc)
