### PR TITLE
Display value when proposal calldata cannot be decoded

### DIFF
--- a/apps/web/src/modules/proposal/components/ProposalDescription/DecodedTransactions.tsx
+++ b/apps/web/src/modules/proposal/components/ProposalDescription/DecodedTransactions.tsx
@@ -58,13 +58,16 @@ export const DecodedTransactions: React.FC<DecodedTransactionProps> = ({
         chain: chainId,
       })
 
-      if (decoded?.data?.statusCode) return calldata
+      if (decoded?.data?.statusCode) throw new Error('Decode failed')
 
       return decoded.data
     } catch (err) {
       console.log('err', err)
 
-      // if err return original calldata
+      // if this tx has value display it as a send eth tx
+      if (value.length && parseInt(value)) return formatSendEth(value)
+
+      // if no value return original calldata
       return calldata
     }
   }


### PR DESCRIPTION
## Description

Fixes an issue where proposal value would not display when transaction calldata could not be deocded

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have done a self-review of my own code
- [ ] Any new and existing tests pass locally with my changes
- [ ] My changes generate no new warnings (lint warnings, console warnings, etc)
