### PR TITLE
Add transaction hash of executed proposal to subgraph

### DIFF
--- a/apps/subgraph/schema.graphql
+++ b/apps/subgraph/schema.graphql
@@ -73,6 +73,7 @@ type Proposal @entity {
   snapshotBlockNumber: BigInt!
   transactionHash: Bytes!
   votes: [ProposalVote!]! @derivedFrom(field: "proposal")
+  executionHash: Bytes
 }
 
 enum ProposalVoteSupport {

--- a/apps/subgraph/schema.graphql
+++ b/apps/subgraph/schema.graphql
@@ -16,6 +16,7 @@ type DAO @entity {
   totalAuctionSales: BigInt!
   auctionConfig: AuctionConfig!
   currentAuction: Auction
+  metadataUpdateHashes: [Bytes!]
   owners: [DAOTokenOwner!]! @derivedFrom(field: "dao")
   tokens: [Token!]! @derivedFrom(field: "dao")
   proposals: [Proposal!]! @derivedFrom(field: "dao")
@@ -73,7 +74,6 @@ type Proposal @entity {
   snapshotBlockNumber: BigInt!
   transactionHash: Bytes!
   votes: [ProposalVote!]! @derivedFrom(field: "proposal")
-  executionHash: Bytes
 }
 
 enum ProposalVoteSupport {

--- a/apps/subgraph/src/governor.ts
+++ b/apps/subgraph/src/governor.ts
@@ -83,6 +83,7 @@ export function handleProposalExecuted(event: ProposalExecutedEvent): void {
   let proposal = new Proposal(event.params.proposalId.toHexString())
   proposal.executed = true
   proposal.queued = false
+  proposal.executionHash = event.transaction.hash
   proposal.save()
 }
 

--- a/apps/subgraph/src/governor.ts
+++ b/apps/subgraph/src/governor.ts
@@ -83,7 +83,6 @@ export function handleProposalExecuted(event: ProposalExecutedEvent): void {
   let proposal = new Proposal(event.params.proposalId.toHexString())
   proposal.executed = true
   proposal.queued = false
-  proposal.executionHash = event.transaction.hash
   proposal.save()
 }
 

--- a/apps/subgraph/src/metadata.ts
+++ b/apps/subgraph/src/metadata.ts
@@ -40,10 +40,8 @@ export function handleAddProperties(event: AddPropertiesFunctionCall): void {
     newHashes = [thisHash]
   } else {
     // copy past transaction hashes
-    for (let i = 0; i < pastHashes.length; i++) {
-      newHashes[i] = pastHashes[i]
-    }
-    newHashes[pastHashes.length] = thisHash
+    newHashes = pastHashes
+    newHashes.push(thisHash)
   }
   dao.metadataUpdateHashes = newHashes
   dao.save()

--- a/apps/subgraph/src/metadata.ts
+++ b/apps/subgraph/src/metadata.ts
@@ -1,10 +1,11 @@
 import { DAO } from '../generated/schema'
 import {
+  AddPropertiesCall as AddPropertiesFunctionCall,
   ContractImageUpdated as ContractImageUpdatedEvent,
   DescriptionUpdated as DescriptionUpdatedEvent,
   WebsiteURIUpdated as URIUpdatedEvent,
 } from '../generated/templates/MetadataRenderer/MetadataRenderer'
-import { dataSource } from '@graphprotocol/graph-ts'
+import { Bytes, dataSource } from '@graphprotocol/graph-ts'
 
 export function handleContractImageUpdated(event: ContractImageUpdatedEvent): void {
   let context = dataSource.context()
@@ -24,5 +25,26 @@ export function handleDescriptionUpdated(event: DescriptionUpdatedEvent): void {
   let context = dataSource.context()
   let dao = DAO.load(context.getString('tokenAddress'))!
   dao.description = event.params.newDescription
+  dao.save()
+}
+
+export function handleAddProperties(event: AddPropertiesFunctionCall): void {
+  let context = dataSource.context()
+  let dao = DAO.load(context.getString('tokenAddress'))!
+  let thisHash = event.transaction.hash
+  let pastHashes = dao.metadataUpdateHashes
+
+  let newHashes: Bytes[] = []
+  if (pastHashes == null) {
+    // initialize array if it doesn't exist
+    newHashes = [thisHash]
+  } else {
+    // copy past transaction hashes
+    for (let i = 0; i < pastHashes.length; i++) {
+      newHashes[i] = pastHashes[i]
+    }
+    newHashes[pastHashes.length] = thisHash
+  }
+  dao.metadataUpdateHashes = newHashes
   dao.save()
 }

--- a/apps/subgraph/subgraph.yaml
+++ b/apps/subgraph/subgraph.yaml
@@ -104,6 +104,9 @@ templates:
           handler: handleDescriptionUpdated
         - event: WebsiteURIUpdated(string,string)
           handler: handleWebsiteURIUpdated
+      callHandlers:
+        - function: addProperties(string[],(uint256,string,bool)[],(string,string)
+          handler: handleAddProperties
       file: ./src/metadata.ts
   - kind: ethereum
     name: Auction

--- a/apps/subgraph/subgraph.yaml
+++ b/apps/subgraph/subgraph.yaml
@@ -105,7 +105,7 @@ templates:
         - event: WebsiteURIUpdated(string,string)
           handler: handleWebsiteURIUpdated
       callHandlers:
-        - function: addProperties(string[],(uint256,string,bool)[],(string,string)
+        - function: addProperties(string[],(uint256,string,bool)[],(string,string))
           handler: handleAddProperties
       file: ./src/metadata.ts
   - kind: ethereum


### PR DESCRIPTION
## Description
This is a small change to add the hash of a proposal's execution to the Proposal entity in the subgraph when the Proposal is actually executed.

## Motivation & context
This is needed to get the hash of the migration transaction on the L1 side, in order to get the Merkle root on the L2 side.

## Code review
Will need to deploy - I'm not sure exactly how to do this.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have done a self-review of my own code
- [x] Any new and existing tests pass locally with my changes
- [x] My changes generate no new warnings (lint warnings, console warnings, etc)
