### PR TITLE
fix useContractReads state dumping

### DIFF
--- a/apps/web/src/hooks/useVotes.ts
+++ b/apps/web/src/hooks/useVotes.ts
@@ -18,6 +18,7 @@ export const useVotes = ({
   const { data, isLoading } = useContractReads({
     enabled: !!collectionAddress && !!governorAddress && !!signerAddress,
     allowFailure: false,
+    keepPreviousData: true,
     contracts: [
       {
         address: collectionAddress as AddressType,

--- a/apps/web/src/modules/proposal/components/ProposalActions/ProposalActions.tsx
+++ b/apps/web/src/modules/proposal/components/ProposalActions/ProposalActions.tsx
@@ -37,6 +37,7 @@ export const ProposalActions: React.FC<ProposalActionsProps> = ({
   const { data } = useContractReads({
     enabled: !!userAddress,
     allowFailure: false,
+    keepPreviousData: true,
     contracts: [
       {
         abi: governorAbi,

--- a/apps/web/src/pages/dao/[network]/[token]/vote/[id].tsx
+++ b/apps/web/src/pages/dao/[network]/[token]/vote/[id].tsx
@@ -13,9 +13,7 @@ import { Meta } from 'src/components/Meta'
 import { CACHE_TIMES } from 'src/constants/cacheTimes'
 import { PUBLIC_DEFAULT_CHAINS } from 'src/constants/defaultChains'
 import SWR_KEYS from 'src/constants/swrKeys'
-import {
-  getProposalState,
-} from 'src/data/contract/requests/getProposalState'
+import { getProposalState } from 'src/data/contract/requests/getProposalState'
 import { SDK } from 'src/data/subgraph/client'
 import {
   formatAndFetchState,


### PR DESCRIPTION
## Description

Adds ``keepPreviousData : true`` to useContractReads to useVotes hook and ProposalActions 

 

## Motivation & context

wagmi useContractReads hook was forcing page re-renders due to a bug with state/caching persistence 

https://github.com/wagmi-dev/wagmi/issues/2878

Took a bit of digging, but I was able to find a parameter that would stop this from happening 

 ``keepPreviousData : true``
 
 This solves both issues: 
 1) Proposal description and title being deleted on first login on network switch
 2) Vote modal closing and deleting vote reason data on vote page. 

## Code review



## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have done a self-review of my own code
- [x] Any new and existing tests pass locally with my changes
- [x] My changes generate no new warnings (lint warnings, console warnings, etc)
