### PR TITLE
Add Farcaster NFT meta tags

### DIFF
--- a/apps/web/src/components/Meta.tsx
+++ b/apps/web/src/components/Meta.tsx
@@ -2,6 +2,7 @@ import Head from 'next/head'
 import React from 'react'
 
 import { PUBLIC_IS_TESTNET } from 'src/constants/defaultChains'
+import { AddressType, Chain } from 'src/typings'
 
 interface MetaProps {
   title: string
@@ -9,9 +10,16 @@ interface MetaProps {
   type?: string
   image?: string
   description?: string
+  farcaster?: {
+    name: string
+    contractAddress: AddressType
+    chain: Chain
+    image: string
+  }
 }
 
-export const Meta: React.FC<MetaProps> = ({ title, type, slug, image, description }) => {
+export const Meta: React.FC<MetaProps> = ({ title, type, slug, image, description, farcaster }) => {
+  // @ts-ignore
   return (
     <Head>
       <title>{`Nouns Builder | ${title}`}</title>
@@ -47,6 +55,19 @@ export const Meta: React.FC<MetaProps> = ({ title, type, slug, image, descriptio
         name="twitter:image"
         content={image || 'https://nouns.build/social-preview.jpg'}
       />
+
+      {/* Warpcast-specific NFT meta tags: https://warpcast.notion.site/NFT-extended-Open-Graph-Spec-4e350bd8e4c34e3b86e77d58bf1f5575 */}
+      {farcaster && (
+        <>
+          <meta name="eth:nft:collection" content={farcaster.name} />
+          <meta name="eth:nft:contract_address" content={farcaster.contractAddress} />
+          {/* Is there a better address we can use for the creator? */}
+          <meta name="eth:nft:creator_address" content={farcaster.contractAddress} />
+          <meta name="eth:nft:schema" content="erc721" />
+          <meta name="eth:nft:chain" content={farcaster.chain.slug} />
+          <meta name="eth:nft:media_url" content={farcaster.image} />
+        </>
+      )}
     </Head>
   )
 }

--- a/apps/web/src/components/Meta.tsx
+++ b/apps/web/src/components/Meta.tsx
@@ -19,7 +19,6 @@ interface MetaProps {
 }
 
 export const Meta: React.FC<MetaProps> = ({ title, type, slug, image, description, farcaster }) => {
-  // @ts-ignore
   return (
     <Head>
       <title>{`Nouns Builder | ${title}`}</title>

--- a/apps/web/src/pages/dao/[network]/[token]/[tokenId].tsx
+++ b/apps/web/src/pages/dao/[network]/[token]/[tokenId].tsx
@@ -143,7 +143,7 @@ const TokenPage: NextPageWithLayout<TokenPageProps> = ({
           name,
           contractAddress: collection,
           chain,
-          image: token.image,
+          image: token.image || ogImageURL,
         }}
       />
 

--- a/apps/web/src/pages/dao/[network]/[token]/[tokenId].tsx
+++ b/apps/web/src/pages/dao/[network]/[token]/[tokenId].tsx
@@ -1,6 +1,7 @@
 import { Flex } from '@zoralabs/zord'
 import axios from 'axios'
 import { GetServerSideProps } from 'next'
+import Head from 'next/head'
 import { useRouter } from 'next/router'
 import React, { useMemo } from 'react'
 import useSWR from 'swr'
@@ -140,6 +141,16 @@ const TokenPage: NextPageWithLayout<TokenPageProps> = ({
         slug={url}
         description={ogDescription}
       />
+
+      <Head>
+        {/* Warpcast-specific NFT meta tags: https://warpcast.notion.site/NFT-extended-Open-Graph-Spec-4e350bd8e4c34e3b86e77d58bf1f5575 */}
+        <meta name="eth:nft:collection" content={name} />
+        <meta name="eth:nft:contract_address" content={collection} />
+        {/* Is there a better address we can use for the creator? */}
+        <meta name="eth:nft:creator_address" content={collection} />
+        <meta name="eth:nft:schema" content="erc721" />
+        <meta name="eth:nft:chain" content={chain.slug} />
+      </Head>
 
       <DaoTopSection
         chain={chain}

--- a/apps/web/src/pages/dao/[network]/[token]/[tokenId].tsx
+++ b/apps/web/src/pages/dao/[network]/[token]/[tokenId].tsx
@@ -140,17 +140,13 @@ const TokenPage: NextPageWithLayout<TokenPageProps> = ({
         image={ogImageURL}
         slug={url}
         description={ogDescription}
+        farcaster={{
+          name,
+          contractAddress: collection,
+          chain,
+          image: token.image,
+        }}
       />
-
-      <Head>
-        {/* Warpcast-specific NFT meta tags: https://warpcast.notion.site/NFT-extended-Open-Graph-Spec-4e350bd8e4c34e3b86e77d58bf1f5575 */}
-        <meta name="eth:nft:collection" content={name} />
-        <meta name="eth:nft:contract_address" content={collection} />
-        {/* Is there a better address we can use for the creator? */}
-        <meta name="eth:nft:creator_address" content={collection} />
-        <meta name="eth:nft:schema" content="erc721" />
-        <meta name="eth:nft:chain" content={chain.slug} />
-      </Head>
 
       <DaoTopSection
         chain={chain}

--- a/apps/web/src/pages/dao/[network]/[token]/[tokenId].tsx
+++ b/apps/web/src/pages/dao/[network]/[token]/[tokenId].tsx
@@ -1,7 +1,6 @@
 import { Flex } from '@zoralabs/zord'
 import axios from 'axios'
 import { GetServerSideProps } from 'next'
-import Head from 'next/head'
 import { useRouter } from 'next/router'
 import React, { useMemo } from 'react'
 import useSWR from 'swr'

--- a/apps/web/src/pages/dao/[network]/[token]/[tokenId].tsx
+++ b/apps/web/src/pages/dao/[network]/[token]/[tokenId].tsx
@@ -143,7 +143,7 @@ const TokenPage: NextPageWithLayout<TokenPageProps> = ({
           name,
           contractAddress: collection,
           chain,
-          image: token.image || ogImageURL,
+          image: ogImageURL,
         }}
       />
 


### PR DESCRIPTION
## Description

Implement Warpcast NFT meta tags, so that links shared on Farcaster render as NFTs rather than plain OG links.

## Motivation & context

Seen a couple people asking about this in the Builder channel on FC: https://warpcast.com/valcoholics/0x49a1cc8a

## Code review

First time contributor and don't have the repo set up to be able to test locally. Would appreciate if someone could help me test! (I can check that the tags are working on the preview, but haven't run the linter etc)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have done a self-review of my own code
- [ ] Any new and existing tests pass locally with my changes
- [ ] My changes generate no new warnings (lint warnings, console warnings, etc)
