### PR TITLE
Add note about transaction fees

### DIFF
--- a/ReplaceArtworkForm.tsx
+++ b/ReplaceArtworkForm.tsx
@@ -1,0 +1,24 @@
+<Box w={'100%'}>
+  <Text fontWeight={'display'} mt="x8">
+    Requirements for Replace Artwork proposal:
+  </Text>
+  <Box as="ul" color="text3" mt="x6">
+    <Box as="li" mb="x3">
+      The total number of new traits must be equal to or greater than the number of
+      old traits
+    </Box>
+    <Box as="li" mb="x3">
+      For each trait, the number of new variants must be equal to or greater than the
+      number of old variants.
+    </Box>
+    <Box as="li">
+      To determine the minimum number of variants required for each trait, refer to
+      the current trait position within the overall folder e.g. Top Layer, Layer #1,
+      Base layer etc.
+    </Box>
+    <Box as="li" mb="x3" color="red" fontWeight="bold">
+      Please note that if the collection has a large amount of traits then the
+      transaction fees can become very large (in the thousands of dollars).
+    </Box>
+  </Box>
+</Box>


### PR DESCRIPTION
## Description

This adds a final bullet point under the 3 existing for "Requirements for Replace Artwork proposal:" and highlights to the user that it could incur serious gas fees. The bullet point is bold/red to warn the user.

## Motivation & context

This will help future DAO members understand the high gas fees associated with both proposing and executing a transaction to repalce the artwork. 

## Code review

Should be fairly straightforward - a basic addition of a singular bullet point.

## Type of change

Provides more context to a user before they initiate a costly trait update proposal.

## Checklist

- [x] I have done a self-review of my own code
- [X] Any new and existing tests pass locally with my changes
- [X] My changes generate no new warnings (lint warnings, console warnings, etc)
