### PR TITLE
Update LayerBox.tsx

### DIFF
--- a/apps/web/src/components/Artwork/LayerBox.tsx
+++ b/apps/web/src/components/Artwork/LayerBox.tsx
@@ -23,6 +23,8 @@ interface Trait {
 export type OrderedTraits = Array<Trait>
 
 export const getLayerName = (idx: number, layers?: OrderedTraits): string => {
+  const maxIdx = layers ? layers.length - 1 : 0;
+  
   if (idx === 0) {
     return 'Top layer'
   }
@@ -31,7 +33,7 @@ export const getLayerName = (idx: number, layers?: OrderedTraits): string => {
     return 'Base layer'
   }
 
-  return `Layer #${idx}`
+  return `Layer #${maxIdx - idx}`
 }
 
 export interface DragAndDropProps {


### PR DESCRIPTION
Adjust the artwork layer labels to reflect more logical ordering. This new label also reflects the numbering used in proposal transactions for artwork adjustments.

 e.g.
Base Layer -> Layer #1 -> Layer #2 -> Layer #3 -> Top Layer

Previous code would have labeled them as:
Base Layer -> Layer #3 -> Layer #2 -> Layer #1 -> Top Layer