### PR TITLE
Fix issue with availible upgrade hook

### DIFF
--- a/apps/web/src/modules/create-proposal/hooks/useAvailableUpgrade.ts
+++ b/apps/web/src/modules/create-proposal/hooks/useAvailableUpgrade.ts
@@ -74,7 +74,10 @@ export const useAvailableUpgrade = ({
         ...contract,
         functionName: 'contractVersion',
       },
-
+      {
+        ...contract,
+        functionName: 'getLatestVersions',
+      },
       {
         ...contract,
         functionName: 'getDAOVersions',
@@ -104,6 +107,7 @@ export const useAvailableUpgrade = ({
 
   const [
     paused,
+    managerVersion,
     latest,
     versions,
     tokenImpl,
@@ -143,18 +147,28 @@ export const useAvailableUpgrade = ({
   }
 
   const getUpgradesForVersion = (
-    versions: DaoVersions,
-    version: string
+    daoVersions: DaoVersions,
+    givenVersion: DaoVersions
   ): Record<AddressType, string> =>
-    pickBy(versions, (v) => isNil(v) || v === '' || lt(v, version))
+    pickBy(daoVersions, (val, key) => {
+      return isNil(val) || val === '' || lt(val, givenVersion[key as keyof DaoVersions])
+    })
 
-  const givenVersion = contractVersion ? contractVersion : latest
+  const givenVersion: DaoVersions = contractVersion
+    ? {
+        token: contractVersion,
+        governor: contractVersion,
+        auction: contractVersion,
+        metadata: contractVersion,
+        treasury: contractVersion,
+      }
+    : latest
   const upgradesNeededForGivenVersion = getUpgradesForVersion(daoVersions, givenVersion)
 
   // meets the required given version, no upgrades needed
   if (Object.values(upgradesNeededForGivenVersion).length === 0) {
     return {
-      latest,
+      latest: managerVersion,
       currentVersions: daoVersions,
       shouldUpgrade: false,
       transaction: undefined,
@@ -241,16 +255,16 @@ export const useAvailableUpgrade = ({
 
   const upgrade = {
     type: TransactionType.UPGRADE,
-    summary: `Upgrade contracts to Nouns Builder v${latest}`,
+    summary: `Upgrade contracts to Nouns Builder v${managerVersion}`,
     transactions: withPauseUnpause(paused, upgradeTransactions),
   }
 
   return {
-    latest,
+    latest: managerVersion,
     shouldUpgrade: noActiveUpgradeProposal,
     currentVersions: daoVersions,
-    date: CONTRACT_VERSION_DETAILS?.[latest]['date'],
-    description: `This release upgrades the DAO to v${latest} to add several features, improvements and bug fixes.`,
+    date: CONTRACT_VERSION_DETAILS?.[managerVersion]['date'],
+    description: `This release upgrades the DAO to v${managerVersion} to add several features, improvements and bug fixes.`,
     totalContractUpgrades: upgradeTransactions.length,
     activeUpgradeProposalId: activeUpgradeProposal?.proposalId,
     transaction: upgrade,


### PR DESCRIPTION
## Description

- Fixes an issue where an upgrade is shown even if the DAO is using the latest contracts. 
- Changes `useAvailableUpgrade` hook to checksagainst each individual contract version instead of checking against the manager version.

## Code review

- Ensure no upgrade is shown if DAO is on the latest contracts.
- Ensure an upgrade is shown if a DAO is not on the latest contracts.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have done a self-review of my own code
- [ ] Any new and existing tests pass locally with my changes
- [ ] My changes generate no new warnings (lint warnings, console warnings, etc)
