### PR TITLE
Fix tokenId 0 auction issue

### DIFF
--- a/apps/web/src/modules/auction/components/Auction.tsx
+++ b/apps/web/src/modules/auction/components/Auction.tsx
@@ -57,7 +57,9 @@ export const Auction: React.FC<AuctionControllerProps> = ({
     unpackOptionalArray(auction, 6)
 
   const isTokenActiveAuction =
-    !settled && !!currentTokenId && currentTokenId.toString() == queriedTokenId
+    !settled &&
+    currentTokenId !== undefined &&
+    currentTokenId.toString() == queriedTokenId
 
   useAuctionEvents({
     chainId: chain.id,


### PR DESCRIPTION
## Description

Fixes an issue where auctions for tokenId 0 would only show bid history and not auctions controls.

## Code review

Are bid controls shown for tokenId 0

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have done a self-review of my own code
- [ ] Any new and existing tests pass locally with my changes
- [ ] My changes generate no new warnings (lint warnings, console warnings, etc)
