### PR TITLE
Fix an issue where L1 deployment was disabled

### DIFF
--- a/apps/web/src/modules/create-dao/components/ReviewAndDeploy/ReviewAndDeploy.tsx
+++ b/apps/web/src/modules/create-dao/components/ReviewAndDeploy/ReviewAndDeploy.tsx
@@ -64,6 +64,7 @@ export const ReviewAndDeploy: React.FC<ReviewAndDeploy> = ({ title }) => {
   const [hasConfirmedRewards, setHasConfirmedRewards] = useState<boolean>(false)
   const [deploymentError, setDeploymentError] = useState<string | undefined>()
   const chain = useChainStore((x) => x.chain)
+  const isL2 = L2_CHAINS.includes(chain.id)
   const { data: version, isLoading: isVersionLoading } = useContractRead({
     abi: managerAbi,
     address: PUBLIC_MANAGER_ADDRESS[chain.id],
@@ -362,7 +363,7 @@ export const ReviewAndDeploy: React.FC<ReviewAndDeploy> = ({ title }) => {
               </Flex>
             </Flex>
 
-            {L2_CHAINS.includes(chain.id) && (
+            {isL2 && (
               <Flex mt="x4">
                 <Flex align={'center'} justify={'center'} gap={'x4'}>
                   <Flex
@@ -420,7 +421,7 @@ export const ReviewAndDeploy: React.FC<ReviewAndDeploy> = ({ title }) => {
                   !address ||
                   !hasConfirmedTerms ||
                   !hasConfirmedChain ||
-                  !hasConfirmedRewards ||
+                  (isL2 && !hasConfirmedRewards) ||
                   isPendingTransaction ||
                   isVersionLoading
                 }


### PR DESCRIPTION
## Description

DAO deployment button is disabled for L1 because of the protocol rewards check not being shown for them.

## Code review

Is the DAO deployment enabled for L1 chains.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have done a self-review of my own code
- [ ] Any new and existing tests pass locally with my changes
- [ ] My changes generate no new warnings (lint warnings, console warnings, etc)
