### PR TITLE
Add auction rewards to preauction page

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,7 +9,6 @@
     "start": "next start",
     "type-check": "tsc --pretty --noEmit",
     "lint": "pnpm type-check && next lint",
-    "postinstall": "pnpm run generate-abis",
     "test": "vitest run",
     "test:watch": "vitest",
     "codegen": "graphql-codegen",

--- a/apps/web/src/data/contract/abis/Auction.ts
+++ b/apps/web/src/data/contract/abis/Auction.ts
@@ -8,8 +8,23 @@ export const auctionAbi = [
       },
       {
         internalType: 'address',
+        name: '_rewardsManager',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
         name: '_weth',
         type: 'address',
+      },
+      {
+        internalType: 'uint16',
+        name: '_builderRewardsBPS',
+        type: 'uint16',
+      },
+      {
+        internalType: 'uint16',
+        name: '_referralRewardsBPS',
+        type: 'uint16',
       },
     ],
     stateMutability: 'payable',
@@ -52,6 +67,11 @@ export const auctionAbi = [
   },
   {
     inputs: [],
+    name: 'CANNOT_CREATE_AUCTION',
+    type: 'error',
+  },
+  {
+    inputs: [],
     name: 'DELEGATE_CALL_FAILED',
     type: 'error',
   },
@@ -68,6 +88,21 @@ export const auctionAbi = [
   {
     inputs: [],
     name: 'INSOLVENT',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'INVALID_REWARDS_BPS',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'INVALID_REWARDS_RECIPIENT',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'INVALID_REWARD_TOTAL',
     type: 'error',
   },
   {
@@ -275,6 +310,31 @@ export const auctionAbi = [
     anonymous: false,
     inputs: [
       {
+        components: [
+          {
+            internalType: 'address',
+            name: 'recipient',
+            type: 'address',
+          },
+          {
+            internalType: 'uint16',
+            name: 'percentBps',
+            type: 'uint16',
+          },
+        ],
+        indexed: false,
+        internalType: 'struct AuctionTypesV2.FounderReward',
+        name: 'reward',
+        type: 'tuple',
+      },
+    ],
+    name: 'FounderRewardUpdated',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
         indexed: false,
         internalType: 'uint256',
         name: 'version',
@@ -466,6 +526,19 @@ export const auctionAbi = [
   },
   {
     inputs: [],
+    name: 'builderRewardsBPS',
+    outputs: [
+      {
+        internalType: 'uint16',
+        name: '',
+        type: 'uint16',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
     name: 'cancelOwnershipTransfer',
     outputs: [],
     stateMutability: 'nonpayable',
@@ -498,6 +571,37 @@ export const auctionAbi = [
     type: 'function',
   },
   {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: '_tokenId',
+        type: 'uint256',
+      },
+      {
+        internalType: 'address',
+        name: '_referral',
+        type: 'address',
+      },
+    ],
+    name: 'createBidWithReferral',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'currentBidReferral',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
     inputs: [],
     name: 'duration',
     outputs: [
@@ -505,6 +609,24 @@ export const auctionAbi = [
         internalType: 'uint256',
         name: '',
         type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'founderReward',
+    outputs: [
+      {
+        internalType: 'address',
+        name: 'recipient',
+        type: 'address',
+      },
+      {
+        internalType: 'uint16',
+        name: 'percentBps',
+        type: 'uint16',
       },
     ],
     stateMutability: 'view',
@@ -536,6 +658,16 @@ export const auctionAbi = [
         internalType: 'uint256',
         name: '_reservePrice',
         type: 'uint256',
+      },
+      {
+        internalType: 'address',
+        name: '_founderRewardRecipient',
+        type: 'address',
+      },
+      {
+        internalType: 'uint16',
+        name: '_founderRewardBps',
+        type: 'uint16',
       },
     ],
     name: 'initialize',
@@ -617,6 +749,19 @@ export const auctionAbi = [
   },
   {
     inputs: [],
+    name: 'referralRewardsBPS',
+    outputs: [
+      {
+        internalType: 'uint16',
+        name: '',
+        type: 'uint16',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
     name: 'reservePrice',
     outputs: [
       {
@@ -650,6 +795,31 @@ export const auctionAbi = [
       },
     ],
     name: 'setDuration',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        components: [
+          {
+            internalType: 'address',
+            name: 'recipient',
+            type: 'address',
+          },
+          {
+            internalType: 'uint16',
+            name: 'percentBps',
+            type: 'uint16',
+          },
+        ],
+        internalType: 'struct AuctionTypesV2.FounderReward',
+        name: 'reward',
+        type: 'tuple',
+      },
+    ],
+    name: 'setFounderReward',
     outputs: [],
     stateMutability: 'nonpayable',
     type: 'function',

--- a/apps/web/src/modules/dao/components/AdminForm/Section.tsx
+++ b/apps/web/src/modules/dao/components/AdminForm/Section.tsx
@@ -2,15 +2,21 @@ import { Box, Text } from '@zoralabs/zord'
 
 interface SectionProps {
   title: string
+  subtitle?: any
   children: React.ReactNode
 }
 
-export const Section: React.FC<SectionProps> = ({ title, children }) => {
+export const Section: React.FC<SectionProps> = ({ title, subtitle, children }) => {
   return (
     <>
       <Text variant="heading-xs" mt="x10">
         {title}
       </Text>
+      {subtitle && (
+        <Text variant="paragraph-md" mt="x2">
+          {subtitle}
+        </Text>
+      )}
       <Box
         borderColor="border"
         borderStyle="solid"

--- a/apps/web/src/modules/dao/components/PreAuctionForm.schema.ts
+++ b/apps/web/src/modules/dao/components/PreAuctionForm.schema.ts
@@ -2,14 +2,27 @@ import * as Yup from 'yup'
 
 import { auctionReservePriceValidationSchema } from 'src/modules/create-dao'
 import { Duration } from 'src/typings'
-import { durationValidationSchema } from 'src/utils/yup'
+import { addressValidationOptionalSchema, durationValidationSchema } from 'src/utils/yup'
 
 export interface PreAuctionFormValues {
   auctionDuration: Duration
   auctionReservePrice: number
+  auctionRewardRecipient?: string
+  auctionRewardPercentage: number
 }
 
 export const preAuctionValidationSchema = Yup.object().shape({
   auctionDuration: durationValidationSchema(),
   auctionReservePrice: auctionReservePriceValidationSchema,
+  auctionRewardRecipient: addressValidationOptionalSchema.when(
+    'auctionRewardPercentage',
+    (auctionRewardPercentage, schema) => {
+      if (auctionRewardPercentage > 0) return schema.required('*') // Recipient is required if reward percentage is greater than 0
+      return schema
+    }
+  ),
+  auctionRewardPercentage: Yup.number()
+    .transform((value) => (isNaN(value) ? undefined : value))
+    .required('*')
+    .max(50, '<= 50%'),
 })

--- a/apps/web/src/modules/dao/components/PreAuctionForm.tsx
+++ b/apps/web/src/modules/dao/components/PreAuctionForm.tsx
@@ -1,4 +1,4 @@
-import { Flex, Stack } from '@zoralabs/zord'
+import { Box, Flex, Stack } from '@zoralabs/zord'
 import { ethers } from 'ethers'
 import { Formik, FormikValues } from 'formik'
 import isEqual from 'lodash/isEqual'
@@ -24,6 +24,7 @@ import {
 } from 'src/utils/helpers'
 
 import { useDaoStore } from '../stores'
+import { Section } from './AdminForm/Section'
 import { PreAuctionFormValues, preAuctionValidationSchema } from './PreAuctionForm.schema'
 
 interface PreAuctionFormSettingsProps {
@@ -162,47 +163,63 @@ export const PreAuctionForm: React.FC<PreAuctionFormSettingsProps> = () => {
             return (
               <Flex direction={'column'} w={'100%'}>
                 <Stack>
-                  <DaysHoursMinsSecs
-                    {...formik.getFieldProps('auctionDuration')}
-                    inputLabel={'Auction Duration'}
-                    formik={formik}
-                    id={'auctionDuration'}
-                    onChange={formik.handleChange}
-                    onBlur={formik.handleBlur}
-                    errorMessage={
-                      formik.touched['auctionDuration'] &&
-                      formik.errors['auctionDuration']
-                        ? formik.errors['auctionDuration']
-                        : undefined
-                    }
-                    placeholder={['1', '0', '0', '0']}
-                  />
+                  <Section title="Auction Settings">
+                    <DaysHoursMinsSecs
+                      {...formik.getFieldProps('auctionDuration')}
+                      inputLabel={'Auction Duration'}
+                      formik={formik}
+                      id={'auctionDuration'}
+                      onChange={formik.handleChange}
+                      onBlur={formik.handleBlur}
+                      errorMessage={
+                        formik.touched['auctionDuration'] &&
+                        formik.errors['auctionDuration']
+                          ? formik.errors['auctionDuration']
+                          : undefined
+                      }
+                      placeholder={['1', '0', '0', '0']}
+                    />
 
-                  <SmartInput
-                    {...formik.getFieldProps('auctionReservePrice')}
-                    inputLabel={'Auction Reserve Price'}
-                    type={NUMBER}
-                    formik={formik}
-                    id={'auctionReservePrice'}
-                    onChange={({ target }: BaseSyntheticEvent) => {
-                      formik.setFieldValue(
-                        'auctionReservePrice',
-                        parseFloat(target.value)
-                      )
-                    }}
-                    onBlur={formik.handleBlur}
-                    helperText={'The starting price of an auction.'}
-                    errorMessage={
-                      formik.touched['auctionReservePrice'] &&
-                      formik.errors['auctionReservePrice']
-                        ? formik.errors['auctionReservePrice']
-                        : undefined
-                    }
-                    perma={'ETH'}
-                  />
+                    <SmartInput
+                      {...formik.getFieldProps('auctionReservePrice')}
+                      inputLabel={'Auction Reserve Price'}
+                      type={NUMBER}
+                      formik={formik}
+                      id={'auctionReservePrice'}
+                      onChange={({ target }: BaseSyntheticEvent) => {
+                        formik.setFieldValue(
+                          'auctionReservePrice',
+                          parseFloat(target.value)
+                        )
+                      }}
+                      onBlur={formik.handleBlur}
+                      helperText={'The starting price of an auction.'}
+                      errorMessage={
+                        formik.touched['auctionReservePrice'] &&
+                        formik.errors['auctionReservePrice']
+                          ? formik.errors['auctionReservePrice']
+                          : undefined
+                      }
+                      perma={'ETH'}
+                    />
+                  </Section>
 
                   {supportsFounderReward && (
-                    <>
+                    <Section
+                      title="Auction Rewards"
+                      subtitle={
+                        <Box color="text3">
+                          DAOs can optionally assign Auction Rewards to an address.{' '}
+                          <a
+                            href="https://docs.zora.co/docs/guides/builder-protocol-rewards"
+                            target="_blank"
+                            rel="noreferrer noopener"
+                          >
+                            learn more
+                          </a>
+                        </Box>
+                      }
+                    >
                       <SmartInput
                         {...formik.getFieldProps('auctionRewardRecipient')}
                         inputLabel="Auction Reward Recipient"
@@ -236,7 +253,7 @@ export const PreAuctionForm: React.FC<PreAuctionFormSettingsProps> = () => {
                           'This is the percentage of final auction bids sent to the Auction Reward Recipient.'
                         }
                       />
-                    </>
+                    </Section>
                   )}
                 </Stack>
 

--- a/apps/web/src/utils/yup/address.schema.ts
+++ b/apps/web/src/utils/yup/address.schema.ts
@@ -36,3 +36,8 @@ const deboucedValidateAddress = async (
 export const addressValidationSchema = Yup.string()
   .required('*')
   .test(deboucedValidateAddress)
+
+export const addressValidationOptionalSchema = Yup.string().test(
+  (value: string | undefined, ctx: Yup.TestContext<any>) =>
+    value ? deboucedValidateAddress(value, ctx) : true
+)


### PR DESCRIPTION
## Description

Adds founder rewards config to preauction page

## Code review

- Does setting auction rewards work on preauction page for V2 DAOs
- Does preauction page function as expected for V1 DAOs

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have done a self-review of my own code
- [ ] Any new and existing tests pass locally with my changes
- [ ] My changes generate no new warnings (lint warnings, console warnings, etc)
