### PR TITLE
Add default version to upgrade hook

### DIFF
--- a/apps/web/src/modules/create-proposal/hooks/useAvailableUpgrade.ts
+++ b/apps/web/src/modules/create-proposal/hooks/useAvailableUpgrade.ts
@@ -131,11 +131,11 @@ export const useAvailableUpgrade = ({
   }
 
   const daoVersions = {
-    governor: versions?.governor,
-    token: versions?.token,
-    treasury: versions?.treasury,
-    auction: versions?.auction,
-    metadata: versions?.metadata,
+    governor: versions?.governor || '1.0.0',
+    token: versions?.token || '1.0.0',
+    treasury: versions?.treasury || '1.0.0',
+    auction: versions?.auction || '1.0.0',
+    metadata: versions?.metadata || '1.0.0',
   }
 
   const managerImplementationAddresses: Record<ContractType, AddressType> = {


### PR DESCRIPTION
## Description

Adds default version so upgrade hook will work with DAOs still on V1.0.0

## Code review

Does upgrade work for DAOs on V1.0.0

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have done a self-review of my own code
- [ ] Any new and existing tests pass locally with my changes
- [ ] My changes generate no new warnings (lint warnings, console warnings, etc)
