### PR TITLE
Add checks for delayed governance

### DIFF
--- a/apps/web/src/data/subgraph/fragments/Dao.graphql
+++ b/apps/web/src/data/subgraph/fragments/Dao.graphql
@@ -2,4 +2,5 @@ fragment DAO on DAO {
   name
   tokenAddress
   auctionAddress
+  governorAddress
 }

--- a/apps/web/src/data/subgraph/sdk.generated.ts
+++ b/apps/web/src/data/subgraph/sdk.generated.ts
@@ -2220,6 +2220,7 @@ export type DaoFragment = {
   name: string
   tokenAddress: any
   auctionAddress: any
+  governorAddress: any
 }
 
 export type ExploreDaoFragment = {
@@ -2433,7 +2434,13 @@ export type DaoTokenOwnersQuery = {
   __typename?: 'Query'
   daotokenOwners: Array<{
     __typename?: 'DAOTokenOwner'
-    dao: { __typename?: 'DAO'; name: string; tokenAddress: any; auctionAddress: any }
+    dao: {
+      __typename?: 'DAO'
+      name: string
+      tokenAddress: any
+      auctionAddress: any
+      governorAddress: any
+    }
   }>
 }
 
@@ -2453,6 +2460,7 @@ export type DashboardQuery = {
       name: string
       tokenAddress: any
       auctionAddress: any
+      governorAddress: any
       auctionConfig: {
         __typename?: 'AuctionConfig'
         minimumBidIncrement: any
@@ -2763,6 +2771,7 @@ export const DaoFragmentDoc = gql`
     name
     tokenAddress
     auctionAddress
+    governorAddress
   }
 `
 export const ExploreDaoFragmentDoc = gql`
@@ -2909,7 +2918,7 @@ export const DaoMembersListDocument = gql`
       id
       owner
       daoTokenCount
-      daoTokens {
+      daoTokens(first: $first) {
         tokenId
         mintedAt
       }

--- a/apps/web/src/hooks/useDelayedGovernance.ts
+++ b/apps/web/src/hooks/useDelayedGovernance.ts
@@ -1,0 +1,25 @@
+import { useContractRead } from 'wagmi'
+
+import { governorAbi } from 'src/data/contract/abis'
+import { AddressType, CHAIN_ID } from 'src/typings'
+
+export const useDelayedGovernance = ({
+  governorAddress,
+  chainId,
+}: {
+  governorAddress?: AddressType
+  chainId: CHAIN_ID
+}) => {
+  const { data: delayedUntilTimestamp } = useContractRead({
+    abi: governorAbi,
+    address: governorAddress,
+    chainId,
+    functionName: 'delayedGovernanceExpirationTimestamp',
+  })
+
+  const isGovernanceDelayed = delayedUntilTimestamp
+    ? new Date().getTime() < Number(delayedUntilTimestamp) * 1000
+    : false
+
+  return { delayedUntilTimestamp, isGovernanceDelayed }
+}

--- a/apps/web/src/modules/dao/components/Activity/Activity.tsx
+++ b/apps/web/src/modules/dao/components/Activity/Activity.tsx
@@ -6,6 +6,7 @@ import useSWR from 'swr'
 import { useAccount } from 'wagmi'
 
 import { ContractButton } from 'src/components/ContractButton'
+import { Countdown } from 'src/components/Countdown'
 import AnimatedModal from 'src/components/Modal/AnimatedModal'
 import { SuccessModalContent } from 'src/components/Modal/SuccessModalContent'
 import Pagination from 'src/components/Pagination'
@@ -15,6 +16,7 @@ import {
   getProposals,
 } from 'src/data/subgraph/requests/proposalsQuery'
 import { useVotes } from 'src/hooks'
+import { useDelayedGovernance } from 'src/hooks/useDelayedGovernance'
 import { usePagination } from 'src/hooks/usePagination'
 import { Upgrade, useProposalStore } from 'src/modules/create-proposal'
 import { ProposalCard } from 'src/modules/proposal'
@@ -60,6 +62,11 @@ export const Activity: React.FC = () => {
     governorAddress: addresses?.governor,
     signerAddress: address,
     collectionAddress: query?.token as AddressType,
+  })
+
+  const { isGovernanceDelayed, delayedUntilTimestamp } = useDelayedGovernance({
+    governorAddress: addresses?.governor,
+    chainId: chain.id,
   })
 
   const [
@@ -150,7 +157,7 @@ export const Activity: React.FC = () => {
               <Button
                 className={submitProposalBtn}
                 onClick={address ? handleProposalCreation : openConnectModal}
-                disabled={address ? !hasThreshold : false}
+                disabled={isGovernanceDelayed ? true : address ? !hasThreshold : false}
                 color={'tertiary'}
               >
                 Submit {!isMobile ? 'proposal' : null}
@@ -166,7 +173,51 @@ export const Activity: React.FC = () => {
           />
         )}
         <Flex direction={'column'} mt={'x6'}>
-          {data?.proposals?.length ? (
+          {isGovernanceDelayed ? (
+            <Flex
+              width={'100%'}
+              mt={'x4'}
+              p={'x4'}
+              justify={'center'}
+              align={'center'}
+              borderColor={'border'}
+              borderStyle={'solid'}
+              borderRadius={'curved'}
+              borderWidth={'normal'}
+            >
+              <Flex textAlign={'center'} align={'center'}>
+                <Text
+                  color={'text3'}
+                  variant={'paragraph-md'}
+                  ml={{ '@initial': 'x0', '@768': 'x3' }}
+                >
+                  Time remaining before proposals can be submitted:
+                </Text>
+              </Flex>
+              <Flex
+                w={{ '@initial': '100%', '@768': 'auto' }}
+                justify={'center'}
+                align={'center'}
+                px={'x2'}
+                py={'x4'}
+              >
+                <Text
+                  fontWeight={'display'}
+                  ml="x1"
+                  style={{
+                    fontVariantNumeric: 'tabular-nums',
+                    fontFeatureSettings: 'tnum',
+                  }}
+                >
+                  <Countdown
+                    end={Number(delayedUntilTimestamp)}
+                    onEnd={() => {}}
+                    style={{ fontWeight: 'bold' }}
+                  />
+                </Text>
+              </Flex>
+            </Flex>
+          ) : data?.proposals?.length ? (
             data?.proposals?.map((proposal, index: number) => (
               <ProposalCard
                 key={index}

--- a/apps/web/src/modules/dashboard/DaoProposals.tsx
+++ b/apps/web/src/modules/dashboard/DaoProposals.tsx
@@ -7,6 +7,7 @@ import React from 'react'
 
 import { Avatar } from 'src/components/Avatar'
 import { PUBLIC_ALL_CHAINS } from 'src/constants/defaultChains'
+import { useDelayedGovernance } from 'src/hooks/useDelayedGovernance'
 import { AddressType } from 'src/typings'
 
 import { DaoProposalCard } from './DaoProposalCard'
@@ -16,6 +17,7 @@ import { daoName } from './dashboard.css'
 export const DaoProposals = ({
   daoImage,
   tokenAddress,
+  governorAddress,
   name,
   proposals,
   chainId,
@@ -24,6 +26,11 @@ export const DaoProposals = ({
   const daoImageSrc = React.useMemo(() => {
     return daoImage ? getFetchableUrl(daoImage) : null
   }, [daoImage])
+
+  const { isGovernanceDelayed } = useDelayedGovernance({
+    governorAddress: governorAddress,
+    chainId,
+  })
 
   const router = useRouter()
 
@@ -61,6 +68,7 @@ export const DaoProposals = ({
           variant="outline"
           borderRadius="curved"
           size={'sm'}
+          disabled={isGovernanceDelayed}
           onClick={() =>
             router.push(`/dao/${currentChainSlug}/${tokenAddress}/proposal/create`)
           }

--- a/apps/web/src/pages/dao/[network]/[token]/proposal/create.tsx
+++ b/apps/web/src/pages/dao/[network]/[token]/proposal/create.tsx
@@ -12,6 +12,7 @@ import { auctionAbi } from 'src/data/contract/abis'
 import { L1_CHAINS } from 'src/data/contract/chains'
 import getDAOAddresses from 'src/data/contract/requests/getDAOAddresses'
 import { useVotes } from 'src/hooks'
+import { useDelayedGovernance } from 'src/hooks/useDelayedGovernance'
 import { getDaoLayout } from 'src/layouts/DaoLayout'
 import {
   CreateProposalHeading,
@@ -65,6 +66,11 @@ const CreateProposalPage: NextPageWithLayout = () => {
     collectionAddress: query?.token as AddressType,
   })
 
+  const { isGovernanceDelayed } = useDelayedGovernance({
+    chainId: chain.id,
+    governorAddress: addresses?.governor,
+  })
+
   const createSelectOption = (type: TransactionFormType) => ({
     value: type,
     label: TRANSACTION_TYPES[type].title,
@@ -92,7 +98,7 @@ const CreateProposalPage: NextPageWithLayout = () => {
 
   if (isLoading) return null
 
-  if (!hasThreshold) {
+  if (!hasThreshold || isGovernanceDelayed) {
     return <Flex className={notFoundWrap}>403 - Access Denied</Flex>
   }
 

--- a/apps/web/src/pages/dao/[network]/[token]/proposal/review.tsx
+++ b/apps/web/src/pages/dao/[network]/[token]/proposal/review.tsx
@@ -9,6 +9,7 @@ import { CACHE_TIMES } from 'src/constants/cacheTimes'
 import { PUBLIC_DEFAULT_CHAINS } from 'src/constants/defaultChains'
 import getDAOAddresses from 'src/data/contract/requests/getDAOAddresses'
 import { useVotes } from 'src/hooks'
+import { useDelayedGovernance } from 'src/hooks/useDelayedGovernance'
 import { getDaoLayout } from 'src/layouts/DaoLayout'
 import {
   CreateProposalHeading,
@@ -38,6 +39,11 @@ const ReviewProposalPage: NextPageWithLayout = () => {
     collectionAddress: query?.token as AddressType,
   })
 
+  const { isGovernanceDelayed } = useDelayedGovernance({
+    chainId: chain.id,
+    governorAddress: addresses?.governor,
+  })
+
   const transactions = useProposalStore((state) => state.transactions)
   const disabled = useProposalStore((state) => state.disabled)
   const title = useProposalStore((state) => state.title)
@@ -45,7 +51,7 @@ const ReviewProposalPage: NextPageWithLayout = () => {
 
   if (isLoading) return null
 
-  if (!hasThreshold) {
+  if (!hasThreshold || isGovernanceDelayed) {
     return <Flex className={notFoundWrap}>403 - Access Denied</Flex>
   }
 


### PR DESCRIPTION
## Description

Ensures DAO users cannot submit proposals when governance is delayed

## Code review

- Check activity tab for a delayed DAO and ensure countdown timer is shown
- Check activity tab for a non delayed DAO and see normal proposals
- try to navigate to `/proposal/create` and `proposal/review` for a delayed DAO and ensure a 403 is returned

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have done a self-review of my own code
- [x] Any new and existing tests pass locally with my changes
- [x] My changes generate no new warnings (lint warnings, console warnings, etc)
