### PR TITLE
Allow migration for Builder, Purple and the Park

### DIFF
--- a/apps/web/src/constants/addresses.ts
+++ b/apps/web/src/constants/addresses.ts
@@ -109,4 +109,7 @@ export const L1_CROSS_DOMAIN_MESSENGER = {
 export const ALLOWED_MIGRATION_DAOS: AddressType[] = [
   '0xf3b8f2ef0933f601c2cceada242fc3948a6ba757',
   '0xc0a2527d25ad9c7dee3f47e3497ca0093def26bc',
+  '0xa45662638e9f3bbb7a6fecb4b17853b7ba0f3a60',
+  '0x96e396e66087b2b9dcad36fd473e1b049df18998',
+  '0xdf9b7d26c8fc806b1ae6273684556761ff02d422',
 ]

--- a/apps/web/src/modules/create-proposal/components/TransactionForm/Migration/MigrateDAOForm.tsx
+++ b/apps/web/src/modules/create-proposal/components/TransactionForm/Migration/MigrateDAOForm.tsx
@@ -6,9 +6,7 @@ import {
   defaultHelperTextStyle,
   defaultInputLabelStyle,
 } from 'src/components/Fields/styles.css'
-import { PUBLIC_ALL_CHAINS } from 'src/constants/defaultChains'
 import { auctionAbi } from 'src/data/contract/abis'
-import { L2_CHAINS } from 'src/data/contract/chains'
 import { TransactionType } from 'src/modules/create-proposal/constants'
 import { usePrepareMigration } from 'src/modules/create-proposal/hooks/usePrepareMigration'
 import { useProposalStore } from 'src/modules/create-proposal/stores'
@@ -19,10 +17,7 @@ import { unpackOptionalArray } from 'src/utils/helpers'
 
 import { DropdownSelect } from '../../DropdownSelect'
 
-const chainOptions = L2_CHAINS.map((chainId) => {
-  const chain = PUBLIC_ALL_CHAINS.find((x) => x.id === chainId)!
-  return { label: chain?.name, value: chainId }
-})
+const chainOptions = [{ label: 'Base', value: CHAIN_ID.BASE }]
 
 export interface MigrationDAOFormProps {
   currentTokenId: bigint


### PR DESCRIPTION
## Description

Adds Builder, Purple and the Park to the allowed migration list. Also removes other networks as an option for migration in favor of base.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have done a self-review of my own code
- [x] Any new and existing tests pass locally with my changes
- [x] My changes generate no new warnings (lint warnings, console warnings, etc)
