### PR TITLE
Add referral query param to token redirect

### DIFF
--- a/apps/web/src/pages/dao/[network]/[token]/index.tsx
+++ b/apps/web/src/pages/dao/[network]/[token]/index.tsx
@@ -116,6 +116,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   const collectionAddress = context?.params?.token as AddressType
   const network = context?.params?.network
   const tab = context?.query?.tab as string
+  const referral = context?.query?.referral as string
 
   const chain = PUBLIC_DEFAULT_CHAINS.find((x) => x.slug === network)
 
@@ -164,11 +165,22 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
       }
     }
 
+    if (!tab && !referral) {
+      return {
+        redirect: {
+          destination: `/dao/${network}/${collectionAddress}/${latestTokenId}`,
+          permanent: false,
+        },
+      }
+    }
+
+    const params = new URLSearchParams()
+    if (tab) params.set('tab', tab)
+    if (referral) params.set('referral', referral)
+
     return {
       redirect: {
-        destination: `/dao/${network}/${collectionAddress}/${latestTokenId}${
-          tab ? `?tab=${tab}` : ''
-        }`,
+        destination: `/dao/${network}/${collectionAddress}/${latestTokenId}?${params.toString()}`,
         permanent: false,
       },
     }


### PR DESCRIPTION
## Description

Allow users to add referral param to `/dao/zora/0x32297b7416294b1acf404b6148a3c58107ba8afd` urls where no tokenId is specified.

## Code review

- Does query string follow the redirect for links with no tokenId

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have done a self-review of my own code
- [x] Any new and existing tests pass locally with my changes
- [x] My changes generate no new warnings (lint warnings, console warnings, etc)
