### PR TITLE
Fix broken Etherscan links for certain chains

### DIFF
--- a/apps/web/src/constants/etherscan.ts
+++ b/apps/web/src/constants/etherscan.ts
@@ -1,13 +1,14 @@
 import { CHAIN_ID } from 'src/typings'
 
+// URLs should not include a trailing forward slash
 export const ETHERSCAN_BASE_URL = {
   [CHAIN_ID.ETHEREUM]: 'https://etherscan.io',
   [CHAIN_ID.OPTIMISM]: 'https://optimistic.etherscan.io',
   [CHAIN_ID.SEPOLIA]: 'https://sepolia.etherscan.io',
-  [CHAIN_ID.OPTIMISM_SEPOLIA]: 'https://sepolia-optimism.etherscan.io/',
-  [CHAIN_ID.BASE]: 'https://basescan.org/',
-  [CHAIN_ID.BASE_SEPOLIA]: 'https://sepolia.basescan.org/',
-  [CHAIN_ID.ZORA]: 'https://explorer.zora.energy/',
-  [CHAIN_ID.ZORA_SEPOLIA]: 'https://sepolia.explorer.zora.energy/',
+  [CHAIN_ID.OPTIMISM_SEPOLIA]: 'https://sepolia-optimism.etherscan.io',
+  [CHAIN_ID.BASE]: 'https://basescan.org',
+  [CHAIN_ID.BASE_SEPOLIA]: 'https://sepolia.basescan.org',
+  [CHAIN_ID.ZORA]: 'https://explorer.zora.energy',
+  [CHAIN_ID.ZORA_SEPOLIA]: 'https://sepolia.explorer.zora.energy',
   [CHAIN_ID.FOUNDRY]: '',
 }


### PR DESCRIPTION
## Description

Remove trailing forward slashes from certain Etherscan base URL constants to fix broken links.

## Motivation & context

Currently Etherscan links created for Optimism Sepolia, Base, Base Sepolia, Zora, and Zora Sepolia are broken because of an additional forward slash when concatenating URLs. It affects any component that includes an Etherscan URL for those chains. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have done a self-review of my own code
- [x] Any new and existing tests pass locally with my changes
- [x] My changes generate no new warnings (lint warnings, console warnings, etc)
