### PR TITLE
feat: make DAO list linkable in user profile

### DIFF
--- a/apps/web/src/modules/dao/components/DaoFeed/DaoFeedSkeleton.tsx
+++ b/apps/web/src/modules/dao/components/DaoFeed/DaoFeedSkeleton.tsx
@@ -3,14 +3,13 @@ import { Box } from '@zoralabs/zord'
 import { exploreSkeleton } from '../Explore/Explore.css'
 import { GridContainer } from './DaoFeed'
 
-export const DaoFeedCardSkeleton = ({ key }: { key?: any }) => {
+export const DaoFeedCardSkeleton = () => {
   return (
     <Box
-      key={key}
       borderRadius="curved"
       backgroundColor="background2"
       width={'100%'}
-      aspectRatio={1 / 1}
+      aspectRatio={1}
       position="relative"
       className={exploreSkeleton}
     />

--- a/apps/web/src/modules/dashboard/DaoAuctionCard.tsx
+++ b/apps/web/src/modules/dashboard/DaoAuctionCard.tsx
@@ -13,6 +13,7 @@ import { auctionAbi } from 'src/data/contract/abis'
 import { useCountdown, useIsMounted } from 'src/hooks'
 import { AddressType } from 'src/typings'
 
+import { chainIdToSlug } from '../../utils/helpers'
 import { overflowEllipsis } from '../auction/components/Auction.css'
 import { AuctionPaused } from './AuctionPaused'
 import { BidActionButton } from './BidActionButton'
@@ -75,7 +76,7 @@ export const DaoAuctionCard = (props: DaoAuctionCardProps) => {
   const handleSelectAuction = () => {
     router.push(`/dao/${currentChainSlug}/${tokenAddress}`)
   }
-  const currentChainSlug = PUBLIC_ALL_CHAINS.find((chain) => chain.id === chainId)?.slug
+  const currentChainSlug = chainIdToSlug(chainId)
 
   if (!currentAuction) {
     return (

--- a/apps/web/src/pages/profile/[user].tsx
+++ b/apps/web/src/pages/profile/[user].tsx
@@ -18,7 +18,7 @@ import { useLayoutStore } from 'src/stores'
 import { useChainStore } from 'src/stores/useChainStore'
 import { artworkSkeleton } from 'src/styles/Artwork.css'
 import { getEnsAddress } from 'src/utils/ens'
-import { walletSnippet } from 'src/utils/helpers'
+import { chainIdToSlug, walletSnippet } from 'src/utils/helpers'
 
 import { NextPageWithLayout } from '../_app'
 import { UserTokensResponse } from '../api/profile/[network]/[user]/tokens'
@@ -51,8 +51,6 @@ const ProfilePage: NextPageWithLayout<ProfileProps> = ({ userAddress }) => {
   const hasDaos = !!daos && daos.length > 0
 
   const { handlePageBack, handlePageForward } = usePagination(tokens?.hasNextPage)
-
-  const daosString = daos?.map((x) => x.name).join(', ')
 
   return (
     <Flex
@@ -118,17 +116,36 @@ const ProfilePage: NextPageWithLayout<ProfileProps> = ({ userAddress }) => {
             <Text mr="x4" fontWeight={'display'}>
               DAOs
             </Text>
-            {isLoading ? (
-              <Box
-                backgroundColor="background2"
-                h="x6"
-                w="100%"
-                className={artworkSkeleton}
-                borderRadius="normal"
-              />
-            ) : (
-              <Text color="text3">{daosString || 'No DAO tokens owned.'}</Text>
-            )}
+            {
+              isLoading ? (
+                  <Box
+                      backgroundColor="background2"
+                      h="x6"
+                      w="100%"
+                      className={artworkSkeleton}
+                      borderRadius="normal"
+                  />
+              ) : (
+                  daos && daos?.length > 0 ? (
+                      <Text color="text3">
+                        {daos.map((dao, index) => (
+                            <>
+                              <Link
+                                  href={`https://nouns.build/dao/${chainIdToSlug(dao.chainId)}/${dao.collectionAddress}`}
+                                  style={{ textDecoration: 'none', color: 'inherit' }}
+                                  className='profile-dao-links'
+                              >
+                                {dao.name}
+                              </Link>
+                              {index < daos.length - 1 && ', '}
+                            </>
+                        ))}
+                      </Text>
+                  ) : (
+                      <Text>No DAO tokens owned.</Text>
+                  )
+              )
+            }
           </Flex>
         </Box>
         {!isMobile && (

--- a/apps/web/src/utils/helpers.ts
+++ b/apps/web/src/utils/helpers.ts
@@ -2,6 +2,7 @@ import isEqual from 'lodash/isEqual'
 import { isAddress } from 'viem'
 
 import { Duration } from 'src/typings'
+import { PUBLIC_ALL_CHAINS } from '../constants/defaultChains'
 
 /**
  *
@@ -276,9 +277,13 @@ export const isPossibleMarkdown = (text: string) => {
     /(?:\*\*[^\*]+\*\*)|(?:__[^\_]+__)|(?:\*[^\*]+\*)|(?:_[^\_]+_)|(?:\#[^\#]+\#)|(?:\!\[[^\]]*\]\([^\)]+\))|(?:\[[^\]]+\]\([^\)]+\))/g
   return markdownRegex.test(text)
 }
+
 export function maxChar(str: string, maxLength: number) {
   if (str.length <= maxLength) {
     return str
   }
   return str.slice(0, maxLength) + '...'
 }
+
+export const chainIdToSlug = (chainId: number) =>
+  PUBLIC_ALL_CHAINS.find((chain) => chain.id === chainId)?.slug

--- a/packages/zoralabs-zord/src/theme.css.ts
+++ b/packages/zoralabs-zord/src/theme.css.ts
@@ -378,3 +378,11 @@ globalStyle('h1,h2,h3,h4,h5,h6,p', {
   padding: 0,
   margin: 0,
 })
+
+globalStyle('.profile-dao-links', {
+  marginRight: '0 !important',
+})
+
+globalStyle('.profile-dao-links::after', {
+  content: 'none !important',
+})


### PR DESCRIPTION
## Description

Adds individual links for each DAO on the user profile page "DAOs" list. Previously it was a somewhat-confusing list of text strings. This feature ideally improves user experience and helps users discover new DAOs when viewing other users' profiles pages.

<img width="243" alt="Screenshot 2024-10-16 at 11 53 54 PM" src="https://github.com/user-attachments/assets/f7253a82-d24e-40fe-9580-98539d60514f">


## Motivation & context

Previously it was a somewhat-confusing list of text strings. This feature ideally improves user experience and helps users discover new DAOs when viewing other users' profiles pages.

## Code review

I also removed a prop that had the name `key` from the `DaoFeedCardSkeleton` component. `key` is a reserved word in React and cannot be used as a prop name. It also served no function as the parent component is already uniquely identified by the same key.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [X] I have done a self-review of my own code
- [X] Any new and existing tests pass locally with my changes
- [X] My changes generate no new warnings (lint warnings, console warnings, etc)
