### PR TITLE
feat: Link recent bidders to their profile pages

### DIFF
--- a/apps/web/src/modules/auction/components/CurrentAuction/Bidder.tsx
+++ b/apps/web/src/modules/auction/components/CurrentAuction/Bidder.tsx
@@ -1,4 +1,5 @@
 import { Box, Flex, Text } from '@zoralabs/zord'
+import Link from 'next/link'
 import React from 'react'
 
 import { Avatar } from 'src/components/Avatar'
@@ -19,7 +20,9 @@ export const Bidder: React.FC<BidderProps> = ({ address }) => {
         <Avatar address={address} src={ensAvatar} size="32" />
       </Box>
       <Text className={recentBidder} variant="paragraph-md">
-        {displayName}
+        <Link href={`/profile/${address}`} passHref>
+          <a>{displayName}</a>
+        </Link>
       </Text>
     </Flex>
   )


### PR DESCRIPTION
## Description

User story: As a user, I would like to navigate to recent bidders' profile pages while an auction is ongoing to see their other DAOs and NFT collection

## Motivation & context
Improves user-friendliness

## Code review

3-liner

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [X] I have done a self-review of my own code
- [X] Any new and existing tests pass locally with my changes
- [X] My changes generate no new warnings (lint warnings, console warnings, etc)
