### PR TITLE
fix: convert properly before using BigInt

### DIFF
--- a/apps/web/src/pages/api/og/dao.tsx
+++ b/apps/web/src/pages/api/og/dao.tsx
@@ -35,20 +35,24 @@ const ptRootBold = fetch(
 ).then((res) => res.arrayBuffer())
 
 const getTreasuryBalance = async (chainId: CHAIN_ID, address: string) => {
-  // query balance directly from the rpc (edge runtime compatible)
+  // Generate a random request ID
+  const requestId = Math.floor(Math.random() * 1_000_000)
+
+  // Query balance directly from the RPC (edge runtime compatible)
   const { result } = await fetch(RPC_URL[chainId], {
     method: 'POST',
     body: JSON.stringify({
       jsonrpc: '2.0',
       method: 'eth_getBalance',
       params: [address, 'latest'],
-      id: 1,
+      id: requestId,
     }),
   }).then((x) => x.json())
 
-  //covert to eth value
-  const eth = BigInt(formatEther(result))
-  const data = formatCryptoVal(eth)
+  // Convert to ETH value
+  const balanceInWei = BigInt(result)
+  const balanceInEth = formatEther(balanceInWei)
+  const data = formatCryptoVal(balanceInEth)
 
   return data
 }


### PR DESCRIPTION
## Description

First convert result to BigInt, then format it with formatEther() which returns a decimal string. Never pass a decimal string into BigInt().

Also changes "id" to a random integer for these reasons:
	1.	Prevents conflicts when making multiple simultaneous requests.
	2.	Helps with debugging by ensuring request-response pairs can be uniquely identified.
	3.	Follows JSON-RPC best practices for tracking responses.

## Motivation & context. 

Fixes this intermittent bug: 
<img width="844" alt="Screenshot 2025-02-06 at 1 07 59 AM" src="https://github.com/user-attachments/assets/01ba3b54-61ea-4cda-a3fc-4400e55748c8" />

<img width="322" alt="Screenshot 2025-02-05 at 11 36 29 PM" src="https://github.com/user-attachments/assets/187410b9-353a-4d89-98ea-1602dab7046b" />

How it looks fixed:  
<img width="322" alt="Screenshot 2025-02-05 at 11 38 40 PM" src="https://github.com/user-attachments/assets/95413355-03da-4e07-b62c-3a72f1ffd436" />

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have done a self-review of my own code
- [x] Any new and existing tests pass locally with my changes
- [x] My changes generate no new warnings (lint warnings, console warnings, etc)
