### PR TITLE
fix: show confirmation dialog always for mainnet daos + fix confirmation text for add artwork form

### DIFF
--- a/apps/web/src/modules/create-proposal/components/TransactionForm/AddArtwork/AddArtworkForm.tsx
+++ b/apps/web/src/modules/create-proposal/components/TransactionForm/AddArtwork/AddArtworkForm.tsx
@@ -1,16 +1,16 @@
-import { PUBLIC_IS_TESTNET } from '@buildeross/constants'
 import { type Property } from '@buildeross/sdk/contract'
-import { NetworkController } from '@buildeross/ui/NetworkController'
 import { Uploading } from '@buildeross/ui/Uploading'
+import { isTestnetChain } from '@buildeross/utils/helpers'
 import { atoms, Box, Button, Flex, Icon, Text } from '@buildeross/zord'
 import { Form, Formik } from 'formik'
 import isEmpty from 'lodash/isEmpty'
 import React, { useState } from 'react'
 import { useArtworkStore } from 'src/modules/create-proposal/stores/useArtworkStore'
+import { useChainStore } from 'src/stores'
 
 import { ArtworkUpload } from '../../ArtworkUpload'
 import { checkboxHelperText, checkboxStyleVariants } from './AddArtworkForm.css'
-import { ArtworkFormValues, validationSchemaArtwork } from './AddArtworkForm.schema'
+import { type ArtworkFormValues, validationSchemaArtwork } from './AddArtworkForm.schema'
 
 export interface InvalidProperty {
   currentVariantCount: number
@@ -45,7 +45,9 @@ export const AddArtworkForm: React.FC<AddArtworkFormProps> = ({
 }) => {
   const { isUploadingToIPFS, ipfsUploadProgress, ipfsUpload, setUpArtwork } =
     useArtworkStore()
-  const [hasConfirmed, setHasConfirmed] = useState(PUBLIC_IS_TESTNET ? true : false)
+  const { id: chainId } = useChainStore((state) => state.chain)
+  const isTestnetDAO = React.useMemo(() => isTestnetChain(chainId), [chainId])
+  const [hasConfirmed, setHasConfirmed] = useState(isTestnetDAO ? true : false)
 
   const initialValues = {
     artwork: setUpArtwork?.artwork || [],
@@ -132,7 +134,7 @@ export const AddArtworkForm: React.FC<AddArtworkFormProps> = ({
                 >{`The trait "${invalidPropertyOrder.trait}" in ${invalidPropertyOrder.invalidLayerName} is not in the correct position. It should be in ${invalidPropertyOrder.layerName}.`}</Text>
               )}
 
-              <NetworkController.Mainnet>
+              {!isTestnetDAO && (
                 <Flex align={'center'} justify={'center'} gap={'x4'} mt="x4">
                   <Flex
                     align={'center'}
@@ -157,7 +159,7 @@ export const AddArtworkForm: React.FC<AddArtworkFormProps> = ({
                     </a>
                   </Flex>
                 </Flex>
-              </NetworkController.Mainnet>
+              )}
 
               <Button
                 mt={'x9'}

--- a/apps/web/src/modules/create-proposal/components/TransactionForm/ReplaceArtwork/ReplaceArtworkForm.tsx
+++ b/apps/web/src/modules/create-proposal/components/TransactionForm/ReplaceArtwork/ReplaceArtworkForm.tsx
@@ -1,15 +1,18 @@
-import { PUBLIC_IS_TESTNET } from '@buildeross/constants/chains'
-import { NetworkController } from '@buildeross/ui/NetworkController'
 import { Uploading } from '@buildeross/ui/Uploading'
+import { isTestnetChain } from '@buildeross/utils/helpers'
 import { atoms, Box, Button, Flex, Icon, Text } from '@buildeross/zord'
 import { Form, Formik } from 'formik'
 import isEmpty from 'lodash/isEmpty'
 import React, { useState } from 'react'
 import { useArtworkStore } from 'src/modules/create-proposal/stores/useArtworkStore'
+import { useChainStore } from 'src/stores'
 
 import { ArtworkUpload } from '../../ArtworkUpload'
 import { checkboxHelperText, checkboxStyleVariants } from './ReplaceArtworkForm.css'
-import { ArtworkFormValues, validationSchemaArtwork } from './ReplaceArtworkForm.schema'
+import {
+  type ArtworkFormValues,
+  validationSchemaArtwork,
+} from './ReplaceArtworkForm.schema'
 
 export interface InvalidProperty {
   currentVariantCount: number
@@ -33,7 +36,9 @@ export const ReplaceArtworkForm: React.FC<ReplaceArtworkFormProps> = ({
 }) => {
   const { isUploadingToIPFS, ipfsUploadProgress, ipfsUpload, setUpArtwork } =
     useArtworkStore()
-  const [hasConfirmed, setHasConfirmed] = useState(PUBLIC_IS_TESTNET ? true : false)
+  const { id: chainId } = useChainStore((state) => state.chain)
+  const isTestnetDAO = React.useMemo(() => isTestnetChain(chainId), [chainId])
+  const [hasConfirmed, setHasConfirmed] = useState(isTestnetDAO ? true : false)
 
   const initialValues = {
     artwork: setUpArtwork?.artwork || [],
@@ -109,7 +114,7 @@ export const ReplaceArtworkForm: React.FC<ReplaceArtworkFormProps> = ({
               >{`${invalidProperty.currentLayerName} currently has ${invalidProperty.currentVariantCount} trait variants. New trait for ${invalidProperty.currentLayerName} "${invalidProperty.nextName}" should also have minimum ${invalidProperty.currentVariantCount} trait variants.`}</Text>
             )}
 
-            <NetworkController.Mainnet>
+            {!isTestnetDAO && (
               <Flex align={'center'} justify={'center'} gap={'x4'} mt="x4">
                 <Flex
                   align={'center'}
@@ -134,7 +139,7 @@ export const ReplaceArtworkForm: React.FC<ReplaceArtworkFormProps> = ({
                   </a>
                 </Flex>
               </Flex>
-            </NetworkController.Mainnet>
+            )}
 
             <Button
               mt={'x9'}

--- a/packages/utils/src/helpers.ts
+++ b/packages/utils/src/helpers.ts
@@ -1,5 +1,5 @@
-import { PUBLIC_ALL_CHAINS } from '@buildeross/constants'
-import { Duration } from '@buildeross/types'
+import { PUBLIC_ALL_CHAINS, TESTNET_CHAINS } from '@buildeross/constants'
+import { CHAIN_ID, Duration } from '@buildeross/types'
 import { isAddress } from 'viem'
 
 /**
@@ -330,5 +330,8 @@ export function maxChar(str: string, maxLength: number) {
   return str.slice(0, maxLength) + '...'
 }
 
-export const chainIdToSlug = (chainId: number): string | undefined =>
+export const chainIdToSlug = (chainId: CHAIN_ID): string | undefined =>
   PUBLIC_ALL_CHAINS.find((chain) => chain.id === chainId)?.slug
+
+export const isTestnetChain = (chainId: CHAIN_ID): boolean =>
+  TESTNET_CHAINS.some((chain) => chain.id === chainId)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Automatic testnet detection adjusts artwork proposal forms based on network.
  * On testnet, confirmation steps and mainnet-only UI elements are adapted or hidden for a smoother flow.
  * Updated wording to “artwork addition proposal” for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->