### PR TITLE
fix: added secondary label to smart input to fix labels

### DIFF
--- a/apps/web/src/modules/create-proposal/components/TransactionForm/CustomTransaction/forms/CustomTransactionForm.tsx
+++ b/apps/web/src/modules/create-proposal/components/TransactionForm/CustomTransaction/forms/CustomTransactionForm.tsx
@@ -2,7 +2,7 @@ import { FieldSwitch, FieldType } from '@buildeross/ui/Fields'
 import { isEmpty } from '@buildeross/utils/helpers'
 import { Button, Flex, Stack } from '@buildeross/zord'
 import { Form, Formik, FormikValues } from 'formik'
-import React, { ReactElement } from 'react'
+import React from 'react'
 import { useCustomTransactionStore } from 'src/modules/create-proposal'
 
 import { backButton, transactionFormButtonWithPrev } from './CustomTransactionForm.css'
@@ -10,7 +10,7 @@ import { backButton, transactionFormButtonWithPrev } from './CustomTransactionFo
 interface FormField {
   name: string
   type: FieldType
-  inputLabel: string | ReactElement
+  inputLabel: string
   helperText?: string
 }
 

--- a/apps/web/src/modules/create-proposal/components/TransactionForm/SendErc20/SendErc20Form.tsx
+++ b/apps/web/src/modules/create-proposal/components/TransactionForm/SendErc20/SendErc20Form.tsx
@@ -399,19 +399,13 @@ export const SendErc20Form = ({ formik }: SendErc20FormProps) => {
 
         <SmartInput
           {...formik.getFieldProps(`amount`)}
-          inputLabel={
-            <Flex justify={'space-between'} width={'100%'}>
-              <Box fontWeight={'label'}>Amount</Box>
-              {fullTokenMetadata && (
-                <Box color={'text3'} fontWeight="paragraph">
-                  Max:{' '}
-                  {formatCryptoVal(
-                    formatUnits(fullTokenMetadata.balance, fullTokenMetadata.decimals)
-                  )}{' '}
-                  {fullTokenMetadata.symbol}
-                </Box>
-              )}
-            </Flex>
+          inputLabel="Amount"
+          secondaryLabel={
+            fullTokenMetadata
+              ? `Max: ${formatCryptoVal(
+                  formatUnits(fullTokenMetadata.balance, fullTokenMetadata.decimals)
+                )} ${fullTokenMetadata.symbol}`
+              : undefined
           }
           id={`amount`}
           type={FIELD_TYPES.NUMBER}

--- a/apps/web/src/modules/create-proposal/components/TransactionForm/SendEth/SendEth.tsx
+++ b/apps/web/src/modules/create-proposal/components/TransactionForm/SendEth/SendEth.tsx
@@ -93,14 +93,8 @@ export const SendEth = () => {
                 <Box mt={'x5'}>
                   <SmartInput
                     {...formik.getFieldProps(`amount`)}
-                    inputLabel={
-                      <Flex justify={'space-between'} width={'100%'}>
-                        <Box fontWeight={'label'}>Amount</Box>
-                        <Box color={'text3'} fontWeight="paragraph">
-                          Treasury Balance: {`${treasuryBalance?.formatted} ETH`}
-                        </Box>
-                      </Flex>
-                    }
+                    inputLabel="Amount"
+                    secondaryLabel={`Treasury Balance: ${treasuryBalance?.formatted} ETH`}
                     id={`amount`}
                     type={FIELD_TYPES.NUMBER}
                     placeholder={'1.0 ETH'}

--- a/apps/web/src/modules/create-proposal/components/TransactionForm/SendNft/SendNft.tsx
+++ b/apps/web/src/modules/create-proposal/components/TransactionForm/SendNft/SendNft.tsx
@@ -437,14 +437,8 @@ const SendNftForm = ({ formik, onNftMetadataChange }: SendNftFormProps) => {
           <Box mt={'x5'}>
             <SmartInput
               {...formik.getFieldProps('amount')}
-              inputLabel={
-                <Flex justify={'space-between'} width={'100%'}>
-                  <Box fontWeight={'label'}>Amount</Box>
-                  <Box color={'text3'} fontWeight="paragraph">
-                    Max: {computedMetadata.balance.toString()}
-                  </Box>
-                </Flex>
-              }
+              inputLabel={'Amount'}
+              secondaryLabel={`Max: ${computedMetadata.balance.toString()}`}
               id="amount"
               type={FIELD_TYPES.NUMBER}
               placeholder={'1'}

--- a/packages/ui/src/Fields/DaysHoursMinsSecs.tsx
+++ b/packages/ui/src/Fields/DaysHoursMinsSecs.tsx
@@ -1,7 +1,7 @@
 import { Box, Flex, Grid } from '@buildeross/zord'
 import { FormikProps } from 'formik'
 import { motion } from 'framer-motion'
-import React, { ChangeEventHandler, ReactElement } from 'react'
+import React, { ChangeEventHandler } from 'react'
 
 import { Tooltip } from '../Tooltip'
 import NumberInput from './NumberInput'
@@ -14,7 +14,7 @@ import {
 interface DaysHoursMinsProps {
   id: string
   value: any
-  inputLabel: string | ReactElement
+  inputLabel: string
   onChange: ChangeEventHandler
   onBlur?: ChangeEventHandler
   formik?: FormikProps<any>

--- a/packages/ui/src/Fields/FieldSwitch.tsx
+++ b/packages/ui/src/Fields/FieldSwitch.tsx
@@ -1,5 +1,5 @@
 import { FormikProps } from 'formik'
-import React, { BaseSyntheticEvent, ReactElement, ReactNode } from 'react'
+import React, { BaseSyntheticEvent, ReactNode } from 'react'
 
 import Date from './DatePicker'
 import DaysHoursMins from './DaysHoursMins'
@@ -14,7 +14,7 @@ interface FieldSwitchProps {
   field: {
     type: FieldType
     name: string
-    inputLabel: string | ReactElement
+    inputLabel: string
     helperText?: string
     max?: number
     min?: number

--- a/packages/ui/src/Fields/SmartInput.tsx
+++ b/packages/ui/src/Fields/SmartInput.tsx
@@ -3,7 +3,7 @@ import { isEmpty } from '@buildeross/utils/helpers'
 import { atoms, Box, Flex, Icon } from '@buildeross/zord'
 import { FormikProps } from 'formik'
 import { motion } from 'framer-motion'
-import React, { ChangeEventHandler, ReactElement, WheelEvent } from 'react'
+import React, { ChangeEventHandler, WheelEvent } from 'react'
 
 import { Avatar } from '../Avatar'
 import { Tooltip } from '../Tooltip'
@@ -22,7 +22,8 @@ interface SmartInputProps {
   id: string
   value?: string | number
   type: typeof FIELD_TYPES.TEXT | typeof FIELD_TYPES.NUMBER | typeof FIELD_TYPES.TEXTAREA
-  inputLabel?: string | ReactElement
+  inputLabel?: string
+  secondaryLabel?: string
   onChange: ChangeEventHandler
   onBlur?: ChangeEventHandler
   formik?: FormikProps<any>
@@ -56,6 +57,7 @@ const SmartInput: React.FC<SmartInputProps> = ({
   value = '',
   type,
   inputLabel,
+  secondaryLabel,
   onChange,
   onBlur,
   autoSubmit,
@@ -110,14 +112,16 @@ const SmartInput: React.FC<SmartInputProps> = ({
   return (
     <Box as="fieldset" mb={'x8'} p={'x0'} className={defaultFieldsetStyle}>
       {inputLabel && (
-        <Flex
-          align={'center'}
-          gap={'x2'}
-          justify="flex-start"
-          className={defaultInputLabelStyle}
-        >
-          <label>{inputLabel}</label>
-          {tooltip && <Tooltip>{tooltip}</Tooltip>}
+        <Flex align={'center'} justify="space-between" className={defaultInputLabelStyle}>
+          <Flex align={'center'} gap={'x2'} justify="flex-start">
+            <label>{inputLabel}</label>
+            {tooltip && <Tooltip>{tooltip}</Tooltip>}
+          </Flex>
+          {secondaryLabel && (
+            <Box color={'text3'} fontWeight="paragraph">
+              {secondaryLabel}
+            </Box>
+          )}
         </Flex>
       )}
       <Box position="relative">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added secondary labels on form inputs to display contextual info (e.g., Treasury Balance for ETH, Max balance for tokens).

- UI/Style
  - Simplified and standardized input labels across Send ETH, Send ERC20, Send NFT, and duration fields.
  - Moved inline balance info from primary labels to secondary labels for clearer readability.
  - Ensured consistent spacing and alignment between primary and secondary labels for a cleaner form layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->