### PR TITLE
fix: add activity / proposal links for auction paused

### DIFF
--- a/apps/web/src/modules/dashboard/AuctionPaused.tsx
+++ b/apps/web/src/modules/dashboard/AuctionPaused.tsx
@@ -98,7 +98,7 @@ export const AuctionPaused = ({ name, tokenAddress, chain }: PausedType) => {
             Auctions are paused.
           </Text>
         </Flex>
-        <Link link={getDaoLink(chain.id, tokenAddress, "activity")}>
+        <Link link={getDaoLink(chain.id, tokenAddress, 'activity')}>
           <Box
             display={'inline-flex'}
             color="text3"

--- a/packages/create-proposal-ui/src/components/TransactionForm/Escrow/Escrow.tsx
+++ b/packages/create-proposal-ui/src/components/TransactionForm/Escrow/Escrow.tsx
@@ -1,5 +1,5 @@
 import { SWR_KEYS } from '@buildeross/constants/swrKeys'
-import { uploadJson } from '@buildeross/ipfs-service'
+import { uploadJson } from '@buildeross/ipfs-service/upload'
 import { erc20Abi } from '@buildeross/sdk/contract'
 import { getProposals, ProposalsResponse } from '@buildeross/sdk/subgraph'
 import { useChainStore, useDaoStore, useProposalStore } from '@buildeross/stores'
@@ -23,6 +23,9 @@ import EscrowForm from './EscrowForm'
 import { EscrowFormValues } from './EscrowForm.schema'
 import { encodeEscrowData } from './EscrowUtils'
 
+const LIMIT = 20
+const PAGE = 1
+
 export const Escrow: React.FC = () => {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [ipfsUploadError, setIpfsUploadError] = useState<Error | null>(null)
@@ -34,8 +37,11 @@ export const Escrow: React.FC = () => {
   const { addresses } = useDaoStore()
 
   const { data } = useSWR<ProposalsResponse>(
-    addresses.token ? ([SWR_KEYS.PROPOSALS, chain.id, addresses.token] as const) : null,
-    ([, _chainId, _token]) => getProposals(_chainId as CHAIN_ID, _token as string, 1)
+    addresses.token
+      ? ([SWR_KEYS.PROPOSALS, chain.id, addresses.token, LIMIT, PAGE] as const)
+      : null,
+    ([, _chainId, _token, _limit, _page]: [string, CHAIN_ID, string, number, number]) =>
+      getProposals(_chainId, _token, _limit, _page)
   )
 
   const lastProposalId = data?.proposals?.[0]?.proposalNumber ?? 0

--- a/packages/dao-ui/src/components/Activity/Activity.tsx
+++ b/packages/dao-ui/src/components/Activity/Activity.tsx
@@ -46,10 +46,10 @@ export const Activity: React.FC<ActivityProps> = ({
 
   const { data, error, isLoading } = useSWR<ProposalsResponse>(
     addresses.token && chain.id
-      ? ([SWR_KEYS.PROPOSALS, chain.id, addresses.token, page] as const)
+      ? ([SWR_KEYS.PROPOSALS, chain.id, addresses.token, LIMIT, page] as const)
       : null,
-    ([, _chainId, _token, _page]: [string, CHAIN_ID, string, number]) =>
-      getProposals(_chainId, _token, LIMIT, _page)
+    ([, _chainId, _token, _limit, _page]: [string, CHAIN_ID, string, number, number]) =>
+      getProposals(_chainId, _token, _limit, _page)
   )
 
   const { data: membership } = useDaoMembership({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "View activity" link on paused auctions that dynamically becomes "View proposal" and navigates to the matching proposal when available.
  * Link only appears after related on-chain/proposal data finishes loading.

* **Style**
  * Improved link visibility with underlined styling.

* **Refactor**
  * Consolidated pagination/configuration for proposal fetches across components for simpler maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->