### PR TITLE
feat: add toggle for on/off founder token allocations

### DIFF
--- a/packages/create-dao-ui/src/components/AllocationForm/FounderAllocationFields.tsx
+++ b/packages/create-dao-ui/src/components/AllocationForm/FounderAllocationFields.tsx
@@ -1,9 +1,8 @@
 import { Duration } from '@buildeross/types'
 import { DatePicker, SmartInput } from '@buildeross/ui/Fields'
 import { calculateMaxAllocation } from '@buildeross/utils'
-import { Button, Flex, Heading, Icon, Paragraph, Stack, Text } from '@buildeross/zord'
+import { Button, Flex, Icon, Stack, Text } from '@buildeross/zord'
 import { FormikErrors, FormikProps, FormikTouched } from 'formik'
-import React from 'react'
 
 import { FounderAllocationFormValues, TokenAllocation } from '../AllocationForm'
 
@@ -32,12 +31,6 @@ export const FounderAllocationFields = ({
 }: FounderAllocationFieldsProps) => {
   return (
     <Flex position={'relative'} direction={'column'} w={'100%'}>
-      <Heading size="xs">Token Allocation</Heading>
-
-      <Paragraph color="text3" mb={'x6'}>
-        A Founder Address will receive x% of tokens until the specified end date.
-      </Paragraph>
-
       <Stack>
         {values.founderAllocation.map((founder, index) => {
           const isFounder = index === 0

--- a/packages/create-dao-ui/src/components/AllocationForm/Toggle.css.ts
+++ b/packages/create-dao-ui/src/components/AllocationForm/Toggle.css.ts
@@ -15,7 +15,6 @@ export const toggleStyle = style([
         cursor: 'pointer',
       },
     },
-    // width: '42px',
   },
 ])
 
@@ -34,3 +33,13 @@ export const allocationToggleButtonVariants = styleVariants({
   off: [allocationToggleButton, { marginLeft: '-2px' }],
   on: [allocationToggleButton, { marginRight: '-2px' }],
 })
+
+export const plainToggleButton = style([
+  {
+    border: '2px solid #000',
+    background: '#F2F2F2',
+    marginTop: '-2px',
+    marginLeft: '-2px',
+    marginRight: '-2px',
+  },
+])

--- a/packages/create-dao-ui/src/components/AllocationForm/Toggle.tsx
+++ b/packages/create-dao-ui/src/components/AllocationForm/Toggle.tsx
@@ -1,19 +1,32 @@
 import { Flex, Icon } from '@buildeross/zord'
-import React from 'react'
 
-import { allocationToggle, allocationToggleButtonVariants } from './Toggle.css'
+import {
+  allocationToggle,
+  allocationToggleButtonVariants,
+  plainToggleButton,
+} from './Toggle.css'
 
-export const Toggle = ({ on, onToggle }: { on: boolean; onToggle: () => void }) => (
+interface ToggleProps {
+  on: boolean
+  onToggle: () => void
+  variant?: 'default' | 'plain'
+}
+
+export const Toggle = ({ on, onToggle, variant = 'default' }: ToggleProps) => (
   <Flex className={allocationToggle[on ? 'on' : 'off']} onClick={onToggle}>
     <Flex
       h={'x6'}
       w={'x6'}
       borderRadius={'round'}
-      className={allocationToggleButtonVariants[on ? 'on' : 'off']}
+      className={
+        variant === 'plain'
+          ? plainToggleButton
+          : allocationToggleButtonVariants[on ? 'on' : 'off']
+      }
       align={'center'}
       justify={'center'}
     >
-      <Icon id={'handlebarCircle'} />
+      {variant === 'default' && <Icon id={'handlebarCircle'} />}
     </Flex>
   </Flex>
 )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a plain toggle to enable/disable founder token allocation.
  * Founder allocation fields now render only when the toggle is enabled.
  * Disabling allocation sets a single 0% allocation with an end date one month ahead.

* **UI/Style**
  * Added a Token Allocation header and descriptive text.
  * Extended toggle visuals with a plain variant and updated styling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->