### PR TITLE
feat: add pinata folder link to playground

### DIFF
--- a/apps/web/src/modules/playground/components/PlaygroundContent.css.ts
+++ b/apps/web/src/modules/playground/components/PlaygroundContent.css.ts
@@ -26,3 +26,19 @@ export const loadingContainer = style([
     minHeight: 'calc(100vh - 250px)',
   },
 ])
+
+export const exploreHeadingStyle = style([
+  atoms({
+    mb: 'x6',
+  }),
+  {
+    lineHeight: 1,
+    fontWeight: 500,
+    fontSize: '20px',
+    '@media': {
+      '(min-width: 768px)': {
+        fontSize: '28px',
+      },
+    },
+  },
+])

--- a/apps/web/src/modules/playground/components/PlaygroundContent.tsx
+++ b/apps/web/src/modules/playground/components/PlaygroundContent.tsx
@@ -1,10 +1,28 @@
+import { normalizeIPFSUrl } from '@buildeross/ipfs-service/url'
 import { Playground } from '@buildeross/ui/Playground'
-import { Box, Flex, Spinner, Stack, Text } from '@buildeross/zord'
-import React from 'react'
+import { Box, Button, Flex, Icon, Spinner, Stack, Text } from '@buildeross/zord'
+import React, { useMemo } from 'react'
 import type { DaoListItem } from 'src/modules/dashboard/SingleDaoSelector'
 
 import { usePlaygroundData } from '../hooks/usePlaygroundData'
-import { contentWrapper, loadingContainer } from './PlaygroundContent.css'
+import {
+  contentWrapper,
+  exploreHeadingStyle,
+  loadingContainer,
+} from './PlaygroundContent.css'
+
+// Extract folder CID from IPFS URI
+const extractFolderCID = (uri: string): string | null => {
+  const normalized = normalizeIPFSUrl(uri)
+  if (!normalized) return null
+
+  // Remove ipfs:// prefix
+  const path = normalized.replace('ipfs://', '')
+
+  // Extract CID (everything before the first /)
+  const cidMatch = path.match(/^([^\/]+)/)
+  return cidMatch ? cidMatch[1] : null
+}
 
 interface PlaygroundContentProps {
   dao: DaoListItem | undefined
@@ -16,6 +34,21 @@ export const PlaygroundContent: React.FC<PlaygroundContentProps> = ({ dao }) => 
     chainId: dao?.chainId,
     metadataAddress: dao?.addresses.metadata,
   })
+
+  // Get distinct folder CIDs for download links
+  const folderCIDs = useMemo(() => {
+    if (!images?.length) return []
+
+    const cids = new Set<string>()
+    images.forEach((image) => {
+      const cid = extractFolderCID(image.uri)
+      if (cid) {
+        cids.add(cid)
+      }
+    })
+
+    return Array.from(cids)
+  }, [images])
 
   // Show DAO artwork mode (only when DAO is selected)
 
@@ -67,7 +100,42 @@ export const PlaygroundContent: React.FC<PlaygroundContentProps> = ({ dao }) => 
         borderStyle={'solid'}
         borderRadius={'curved'}
         borderWidth={'normal'}
+        gap="x6"
       >
+        {folderCIDs.length > 0 && (
+          <Stack width="100%" align="flex-start">
+            <Text variant="heading-md" className={exploreHeadingStyle}>
+              Explore on IPFS
+            </Text>
+            <Stack gap="x2">
+              {folderCIDs.map((cid) => (
+                <Button
+                  key={cid}
+                  as="a"
+                  href={`https://gateway.pinata.cloud/ipfs/${cid}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  variant="secondary"
+                  px="x4"
+                  style={{
+                    justifyContent: 'space-between',
+                    borderRadius: '12px',
+                    minWidth: '245px',
+                  }}
+                >
+                  <Flex align="center" gap="x2">
+                    <Icon id="globe" size="sm" />
+                    <Text style={{ fontSize: '14px' }}>
+                      {cid.substring(0, 12)}...{cid.substring(cid.length - 8)}
+                    </Text>
+                  </Flex>
+                  <Icon id="external-16" size="sm" />
+                </Button>
+              ))}
+            </Stack>
+          </Stack>
+        )}
+
         <Playground images={images} orderedLayers={orderedLayers} />
       </Flex>
     </Box>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Explore on IPFS" section allowing users to view uploaded images via IPFS gateway links.
  * Displays truncated folder identifiers as interactive buttons with icons linking to Pinata gateway.
  * Section appears only when IPFS content is available.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->