### PR TITLE
fix: use past votes for proposal actions

### DIFF
--- a/packages/feed-ui/src/Actions/FeedItemActions.tsx
+++ b/packages/feed-ui/src/Actions/FeedItemActions.tsx
@@ -40,6 +40,7 @@ export const FeedItemActions: React.FC<FeedItemActionsProps> = ({ item }) => {
           proposalId={item.proposalId}
           proposalNumber={item.proposalNumber}
           proposalTitle={item.proposalTitle}
+          proposalTimeCreated={item.proposalTimeCreated}
           isExecuted={false}
           addresses={item.addresses}
         />
@@ -52,6 +53,7 @@ export const FeedItemActions: React.FC<FeedItemActionsProps> = ({ item }) => {
           proposalId={item.proposalId}
           proposalNumber={item.proposalNumber}
           proposalTitle={item.proposalTitle}
+          proposalTimeCreated={item.proposalTimeCreated}
           isExecuted={false}
           updateItem={item}
           addresses={item.addresses}
@@ -65,6 +67,7 @@ export const FeedItemActions: React.FC<FeedItemActionsProps> = ({ item }) => {
           proposalId={item.proposalId}
           proposalNumber={item.proposalNumber}
           proposalTitle={item.proposalTitle}
+          proposalTimeCreated={item.proposalTimeCreated}
           addresses={item.addresses}
           isExecuted={true}
         />

--- a/packages/feed-ui/src/Actions/ProposalActions.tsx
+++ b/packages/feed-ui/src/Actions/ProposalActions.tsx
@@ -23,6 +23,7 @@ interface ProposalActionsProps {
   proposalId: BytesType
   proposalNumber: string
   proposalTitle: string
+  proposalTimeCreated: string
   addresses: RequiredDaoContractAddresses
   isExecuted?: boolean
   updateItem?: ProposalUpdatePostedFeedItem
@@ -34,6 +35,7 @@ export const ProposalActions: React.FC<ProposalActionsProps> = ({
   proposalId,
   proposalNumber,
   proposalTitle,
+  proposalTimeCreated,
   isExecuted,
   updateItem,
 }) => {
@@ -139,6 +141,7 @@ export const ProposalActions: React.FC<ProposalActionsProps> = ({
         onClose={() => setShowVoteModal(false)}
         proposalId={proposalId}
         proposalTitle={proposalTitle}
+        proposalTimeCreated={proposalTimeCreated}
         chainId={chainId}
         addresses={addresses}
       />

--- a/packages/feed-ui/src/Modals/VoteModalWrapper.tsx
+++ b/packages/feed-ui/src/Modals/VoteModalWrapper.tsx
@@ -17,6 +17,7 @@ export interface VoteModalWrapperProps {
   onClose: () => void
   proposalId: BytesType
   proposalTitle: string
+  proposalTimeCreated: string
   chainId: CHAIN_ID
   addresses: RequiredDaoContractAddresses
 }
@@ -197,6 +198,7 @@ export const VoteModalWrapper: React.FC<VoteModalWrapperProps> = ({
   onClose,
   proposalId,
   proposalTitle,
+  proposalTimeCreated,
   chainId,
   addresses,
 }) => {
@@ -212,6 +214,7 @@ export const VoteModalWrapper: React.FC<VoteModalWrapperProps> = ({
     collectionAddress: addresses.token,
     governorAddress: addresses.governor,
     signerAddress: userAddress,
+    timestamp: BigInt(proposalTimeCreated),
     enabled: isOpen,
   })
 

--- a/packages/hooks/src/useVotes.ts
+++ b/packages/hooks/src/useVotes.ts
@@ -18,12 +18,14 @@ export const useVotes = ({
   collectionAddress,
   governorAddress,
   signerAddress,
+  timestamp,
   enabled = true,
 }: {
   chainId: CHAIN_ID
   collectionAddress?: AddressType
   governorAddress?: AddressType
   signerAddress?: AddressType
+  timestamp?: bigint
   enabled?: boolean
 }): UseVotesReturnType => {
   const { data, isLoading } = useReadContracts({
@@ -35,8 +37,10 @@ export const useVotes = ({
       {
         address: collectionAddress as AddressType,
         abi: tokenAbi,
-        functionName: 'getVotes',
-        args: [signerAddress as AddressType],
+        functionName: timestamp ? 'getPastVotes' : 'getVotes',
+        args: timestamp
+          ? [signerAddress as AddressType, timestamp]
+          : [signerAddress as AddressType],
         chainId,
       },
       {

--- a/packages/proposal-ui/src/components/ProposalActions/ProposalActions.tsx
+++ b/packages/proposal-ui/src/components/ProposalActions/ProposalActions.tsx
@@ -30,6 +30,7 @@ export const ProposalActions: React.FC<ProposalActionsProps> = ({
     collectionAddress: addresses.token,
     governorAddress: addresses.governor,
     signerAddress: userAddress,
+    timestamp: BigInt(proposal.timeCreated),
   })
 
   const { votesAvailable, isProposer, signerVote } = useMemo(() => {

--- a/packages/sdk/codegen.yml
+++ b/packages/sdk/codegen.yml
@@ -1,6 +1,6 @@
 generates:
   src/subgraph/sdk.generated.ts:
-    schema: 'https://api.goldsky.com/api/public/project_cm33ek8kjx6pz010i2c3w8z25/subgraphs/nouns-builder-ethereum-sepolia/0.1.8/gn'
+    schema: 'https://api.goldsky.com/api/public/project_cm33ek8kjx6pz010i2c3w8z25/subgraphs/nouns-builder-ethereum-sepolia/0.1.9/gn'
     documents: 'src/subgraph/**/*.graphql'
     plugins:
       - typescript

--- a/packages/sdk/src/subgraph/queries/feedEvents.graphql
+++ b/packages/sdk/src/subgraph/queries/feedEvents.graphql
@@ -27,10 +27,10 @@ query feedEvents($first: Int!, $where: FeedEvent_filter) {
       proposal {
         proposalId
         proposalNumber
+        timeCreated
         title
         description
         proposer
-        timeCreated
       }
     }
 
@@ -38,6 +38,7 @@ query feedEvents($first: Int!, $where: FeedEvent_filter) {
       proposal {
         proposalId
         proposalNumber
+        timeCreated
         title
         description
         proposer
@@ -53,6 +54,7 @@ query feedEvents($first: Int!, $where: FeedEvent_filter) {
       proposal {
         proposalId
         proposalNumber
+        timeCreated
         title
         description
         proposer
@@ -68,6 +70,7 @@ query feedEvents($first: Int!, $where: FeedEvent_filter) {
       proposal {
         proposalId
         proposalNumber
+        timeCreated
         title
         description
         proposer
@@ -90,8 +93,11 @@ query feedEvents($first: Int!, $where: FeedEvent_filter) {
     ... on AuctionBidPlacedEvent {
       auction {
         id
+        startTime
+        endTime
         token {
           tokenId
+          owner
           name
           image
         }
@@ -106,6 +112,8 @@ query feedEvents($first: Int!, $where: FeedEvent_filter) {
     ... on AuctionSettledEvent {
       auction {
         id
+        startTime
+        endTime
         token {
           tokenId
           owner

--- a/packages/sdk/src/subgraph/requests/feedQuery.ts
+++ b/packages/sdk/src/subgraph/requests/feedQuery.ts
@@ -68,6 +68,7 @@ function transformFeedEvent(event: FeedEvent, chainId: CHAIN_ID): FeedItem {
         proposalNumber: event.proposal.proposalNumber.toString(),
         proposalTitle: event.proposal.title || '',
         proposalDescription: event.proposal.description || '',
+        proposalTimeCreated: String(event.proposal.timeCreated),
         proposer: event.proposal.proposer,
       }
     }
@@ -80,6 +81,7 @@ function transformFeedEvent(event: FeedEvent, chainId: CHAIN_ID): FeedItem {
         proposalNumber: event.proposal.proposalNumber.toString(),
         proposalTitle: event.proposal.title || '',
         proposalDescription: event.proposal.description || '',
+        proposalTimeCreated: String(event.proposal.timeCreated),
         proposer: event.proposal.proposer,
         voter: event.actor,
         reason: event.vote.reason || undefined,
@@ -96,6 +98,7 @@ function transformFeedEvent(event: FeedEvent, chainId: CHAIN_ID): FeedItem {
         proposalNumber: event.proposal.proposalNumber.toString(),
         proposalTitle: event.proposal.title || '',
         proposalDescription: event.proposal.description || '',
+        proposalTimeCreated: String(event.proposal.timeCreated),
         proposer: event.proposal.proposer,
         messageType: event.update.messageType,
         message: event.update.message,
@@ -111,6 +114,7 @@ function transformFeedEvent(event: FeedEvent, chainId: CHAIN_ID): FeedItem {
         proposalNumber: event.proposal.proposalNumber.toString(),
         proposalTitle: event.proposal.title || '',
         proposalDescription: event.proposal.description || '',
+        proposalTimeCreated: String(event.proposal.timeCreated),
         proposer: event.proposal.proposer,
       }
     }

--- a/packages/sdk/src/subgraph/sdk.generated.ts
+++ b/packages/sdk/src/subgraph/sdk.generated.ts
@@ -5041,9 +5041,12 @@ export type FeedEventsQuery = {
         auction: {
           __typename?: 'Auction'
           id: string
+          startTime: any
+          endTime: any
           token: {
             __typename?: 'Token'
             tokenId: any
+            owner: any
             name: string
             image?: string | null
           }
@@ -5105,6 +5108,8 @@ export type FeedEventsQuery = {
         auction: {
           __typename?: 'Auction'
           id: string
+          startTime: any
+          endTime: any
           token: {
             __typename?: 'Token'
             tokenId: any
@@ -5137,10 +5142,10 @@ export type FeedEventsQuery = {
           __typename?: 'Proposal'
           proposalId: any
           proposalNumber: number
+          timeCreated: any
           title?: string | null
           description?: string | null
           proposer: any
-          timeCreated: any
         }
         dao: {
           __typename?: 'DAO'
@@ -5166,6 +5171,7 @@ export type FeedEventsQuery = {
           __typename?: 'Proposal'
           proposalId: any
           proposalNumber: number
+          timeCreated: any
           title?: string | null
           description?: string | null
           proposer: any
@@ -5194,6 +5200,7 @@ export type FeedEventsQuery = {
           __typename?: 'Proposal'
           proposalId: any
           proposalNumber: number
+          timeCreated: any
           title?: string | null
           description?: string | null
           proposer: any
@@ -5228,6 +5235,7 @@ export type FeedEventsQuery = {
           __typename?: 'Proposal'
           proposalId: any
           proposalNumber: number
+          timeCreated: any
           title?: string | null
           description?: string | null
           proposer: any
@@ -6081,16 +6089,17 @@ export const FeedEventsDocument = gql`
         proposal {
           proposalId
           proposalNumber
+          timeCreated
           title
           description
           proposer
-          timeCreated
         }
       }
       ... on ProposalVotedEvent {
         proposal {
           proposalId
           proposalNumber
+          timeCreated
           title
           description
           proposer
@@ -6105,6 +6114,7 @@ export const FeedEventsDocument = gql`
         proposal {
           proposalId
           proposalNumber
+          timeCreated
           title
           description
           proposer
@@ -6119,6 +6129,7 @@ export const FeedEventsDocument = gql`
         proposal {
           proposalId
           proposalNumber
+          timeCreated
           title
           description
           proposer
@@ -6139,8 +6150,11 @@ export const FeedEventsDocument = gql`
       ... on AuctionBidPlacedEvent {
         auction {
           id
+          startTime
+          endTime
           token {
             tokenId
+            owner
             name
             image
           }
@@ -6154,6 +6168,8 @@ export const FeedEventsDocument = gql`
       ... on AuctionSettledEvent {
         auction {
           id
+          startTime
+          endTime
           token {
             tokenId
             owner

--- a/packages/types/src/feed.ts
+++ b/packages/types/src/feed.ts
@@ -52,6 +52,7 @@ export type ProposalCreatedFeedItem = BaseFeedItem & {
   proposalNumber: string
   proposalTitle: string
   proposalDescription: string
+  proposalTimeCreated: string
   proposer: AddressType
 }
 
@@ -61,6 +62,7 @@ export type ProposalVotedFeedItem = BaseFeedItem & {
   proposalNumber: string
   proposalTitle: string
   proposalDescription: string
+  proposalTimeCreated: string
   proposer: AddressType
   voter: AddressType
   reason?: string
@@ -74,6 +76,7 @@ export type ProposalUpdatePostedFeedItem = BaseFeedItem & {
   proposalNumber: string
   proposalTitle: string
   proposalDescription: string
+  proposalTimeCreated: string
   proposer: AddressType
   messageType: number
   message: string
@@ -86,6 +89,7 @@ export type ProposalExecutedFeedItem = BaseFeedItem & {
   proposalNumber: string
   proposalTitle: string
   proposalDescription: string
+  proposalTimeCreated: string
   proposer: AddressType
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vote views support historical snapshots: votes can be retrieved as of a proposal's creation time for accurate past-state views.
  * Proposal feeds, items, and vote dialogs now include proposal creation time so displayed vote data aligns with the proposal timestamp.
  * Feed events expose richer auction and token info (auction start/end times and token owner) for more informative feed entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->