### PR TITLE
fix: founder allocation init values bug

### DIFF
--- a/packages/create-dao-ui/src/components/AllocationForm/AllocationForm.tsx
+++ b/packages/create-dao-ui/src/components/AllocationForm/AllocationForm.tsx
@@ -119,8 +119,8 @@ export const AllocationForm: React.FC<AllocationFormProps> = ({ title }) => {
       ? [
           {
             founderAddress: address || '',
-            allocationPercentage: '',
-            endDate: '',
+            allocationPercentage: 0,
+            endDate: getOneMonthFromNow(),
             admin: true,
           },
         ]
@@ -353,7 +353,6 @@ export const AllocationForm: React.FC<AllocationFormProps> = ({ title }) => {
           </Form>
         )}
       </Formik>
-
       {chain.id === CHAIN_ID.ETHEREUM && <ContributionAllocation />}
 
       {allocationError && (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The founder allocation form now initializes fields when starting a new allocation: allocation percentage defaults to 0% and the end date defaults to one month from today.
  * For new founder entries with no prior allocations, fields no longer appear blank on first load, providing immediate, ready-to-edit values for faster setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->