### PR TITLE
fix: disable sell tab temporarily + move transactionType to useProposalStore

### DIFF
--- a/packages/create-proposal-ui/src/components/TransactionForm/AddArtwork/AddArtwork.tsx
+++ b/packages/create-proposal-ui/src/components/TransactionForm/AddArtwork/AddArtwork.tsx
@@ -10,14 +10,14 @@ import useSWR from 'swr'
 import { encodeFunctionData } from 'viem'
 
 import { useArtworkStore } from '../../../stores/useArtworkStore'
-import { type FormComponent } from '../types'
 import { AddArtworkForm } from './AddArtworkForm'
 
-export const AddArtwork: FormComponent = ({ resetTransactionType }) => {
+export const AddArtwork: React.FC = () => {
   const { orderedLayers, ipfsUpload, isUploadingToIPFS, resetForm } = useArtworkStore()
   const addresses = useDaoStore((x) => x.addresses)
   const chain = useChainStore((x) => x.chain)
   const addTransaction = useProposalStore((state) => state.addTransaction)
+  const resetTransactionType = useProposalStore((state) => state.resetTransactionType)
 
   const contractOrderedLayers = useMemo(
     () => [...orderedLayers].reverse(), // traits in the contract are reversed

--- a/packages/create-proposal-ui/src/components/TransactionForm/ContentCoin/ContentCoin.tsx
+++ b/packages/create-proposal-ui/src/components/TransactionForm/ContentCoin/ContentCoin.tsx
@@ -33,7 +33,6 @@ import React, { useEffect, useMemo, useState } from 'react'
 import { type Address, encodeFunctionData, zeroAddress, zeroHash } from 'viem'
 import { useReadContract } from 'wagmi'
 
-import type { FormComponent } from '../types'
 import { ContentCoinPreviewDisplay } from './ContentCoinPreviewDisplay'
 import { IPFSUploader } from './ipfsUploader'
 
@@ -178,9 +177,10 @@ const ContentCoinEconomicsPreview: React.FC<ContentCoinEconomicsPreviewProps> = 
   }
 }
 
-export const ContentCoin: FormComponent = ({ resetTransactionType }) => {
+export const ContentCoin: React.FC = () => {
   const { treasury, token } = useDaoStore((state) => state.addresses)
   const addTransaction = useProposalStore((state) => state.addTransaction)
+  const resetTransactionType = useProposalStore((state) => state.resetTransactionType)
   const { chain } = useChainStore()
 
   const [submitError, setSubmitError] = useState<string | undefined>()

--- a/packages/create-proposal-ui/src/components/TransactionForm/CreatorCoin/CreatorCoin.tsx
+++ b/packages/create-proposal-ui/src/components/TransactionForm/CreatorCoin/CreatorCoin.tsx
@@ -53,7 +53,6 @@ import {
 import { useBalance } from 'wagmi'
 import { ZodError } from 'zod'
 
-import type { FormComponent } from '../types'
 import { CreatorCoinPreviewDisplay } from './CreatorCoinPreviewDisplay'
 
 const chainNamesString = getChainNamesString(COIN_SUPPORTED_CHAINS)
@@ -361,9 +360,10 @@ const CreatorCoinEconomicsPreview: React.FC<CreatorCoinEconomicsPreviewProps> = 
   }
 }
 
-export const CreatorCoin: FormComponent = ({ resetTransactionType }) => {
+export const CreatorCoin: React.FC = () => {
   const { treasury, token: daoTokenAddress } = useDaoStore((state) => state.addresses)
   const addTransaction = useProposalStore((state) => state.addTransaction)
+  const resetTransactionType = useProposalStore((state) => state.resetTransactionType)
   const { chain } = useChainStore()
 
   const [submitError, setSubmitError] = useState<string | undefined>()

--- a/packages/create-proposal-ui/src/components/TransactionForm/CustomTransaction/CustomTransaction.tsx
+++ b/packages/create-proposal-ui/src/components/TransactionForm/CustomTransaction/CustomTransaction.tsx
@@ -5,13 +5,13 @@ import { motion } from 'framer-motion'
 import React, { ReactNode } from 'react'
 
 import { useCustomTransactionStore } from '../../../stores/useCustomTransactionStore'
-import { type FormComponent } from '../types'
 import { customTransactionWrapper, transactionFormWrapper } from './CustomTransaction.css'
 import { FormHeading } from './FormHeading'
 import { ABI, Address, Arguments, Function, Summary, Value } from './forms'
 
-export const CustomTransaction: FormComponent = ({ resetTransactionType }) => {
-  const { addTransaction } = useProposalStore()
+export const CustomTransaction: React.FC = () => {
+  const addTransaction = useProposalStore((state) => state.addTransaction)
+  const resetTransactionType = useProposalStore((state) => state.resetTransactionType)
 
   const {
     active: activeCustomTransactionSection,

--- a/packages/create-proposal-ui/src/components/TransactionForm/Droposal/Droposal.tsx
+++ b/packages/create-proposal-ui/src/components/TransactionForm/Droposal/Droposal.tsx
@@ -5,19 +5,25 @@ import { AddressType, TransactionType } from '@buildeross/types'
 import { getEnsAddress } from '@buildeross/utils/ens'
 import { Stack } from '@buildeross/zord'
 import { FormikHelpers } from 'formik'
-import { encodeFunctionData, isAddress, parseEther } from 'viem'
+import {
+  encodeFunctionData,
+  isAddress,
+  maxUint32,
+  maxUint64,
+  parseEther,
+  zeroHash,
+} from 'viem'
 
-import { type FormComponent } from '../types'
 import { DroposalForm } from './DroposalForm'
 import { DroposalFormValues } from './DroposalForm.schema'
 
-const UINT_64_MAX = BigInt('18446744073709551615')
-const UINT_32_MAX = BigInt('4294967295')
-const HASH_ZERO =
-  '0x0000000000000000000000000000000000000000000000000000000000000000' as `0x${string}`
+const UINT_64_MAX = maxUint64
+const UINT_32_MAX = maxUint32
+const HASH_ZERO = zeroHash
 
-export const Droposal: FormComponent = ({ resetTransactionType }) => {
+export const Droposal: React.FC = () => {
   const addTransaction = useProposalStore((state) => state.addTransaction)
+  const resetTransactionType = useProposalStore((state) => state.resetTransactionType)
   const chain = useChainStore((x) => x.chain)
 
   const handleDroposalTransaction = async (

--- a/packages/create-proposal-ui/src/components/TransactionForm/FixRendererBase/FixRendererBase.tsx
+++ b/packages/create-proposal-ui/src/components/TransactionForm/FixRendererBase/FixRendererBase.tsx
@@ -2,11 +2,10 @@ import { useRendererBaseFix } from '@buildeross/hooks/useRendererBaseFix'
 import { useChainStore, useDaoStore, useProposalStore } from '@buildeross/stores'
 import { Box, Button, Paragraph } from '@buildeross/zord'
 
-import { type FormComponent } from '../types'
-
-export const FixRendererBase: FormComponent = ({ resetTransactionType }) => {
+export const FixRendererBase: React.FC = () => {
   const addresses = useDaoStore((state) => state.addresses)
   const addTransaction = useProposalStore((state) => state.addTransaction)
+  const resetTransactionType = useProposalStore((state) => state.resetTransactionType)
   const chain = useChainStore((x) => x.chain)
 
   const { shouldFix, transaction } = useRendererBaseFix({

--- a/packages/create-proposal-ui/src/components/TransactionForm/Migration/BridgeTreasuryForm.tsx
+++ b/packages/create-proposal-ui/src/components/TransactionForm/Migration/BridgeTreasuryForm.tsx
@@ -12,18 +12,16 @@ import { Form, Formik } from 'formik'
 import { encodeFunctionData, parseEther } from 'viem'
 import { useBalance } from 'wagmi'
 
-import { type FormComponentProps } from '../types'
 import bridgeTreasuryFormSchema, {
   BridgeTreasuryValues,
 } from './BridgeTreasuryForm.schema'
 
-type BridgeTreasuryFormProps = FormComponentProps & {
+type BridgeTreasuryFormProps = {
   migratedToChainId?: CHAIN_ID
 }
 
 export const BridgeTreasuryForm: React.FC<BridgeTreasuryFormProps> = ({
   migratedToChainId,
-  resetTransactionType,
 }) => {
   const { treasury } = useDaoStore((state) => state.addresses)
   const chain = useChainStore((x) => x.chain)
@@ -32,6 +30,7 @@ export const BridgeTreasuryForm: React.FC<BridgeTreasuryFormProps> = ({
     chainId: chain.id,
   })
   const addTransaction = useProposalStore((state) => state.addTransaction)
+  const resetTransactionType = useProposalStore((state) => state.resetTransactionType)
   const initialValues: BridgeTreasuryValues = {
     amount: 0,
   }

--- a/packages/create-proposal-ui/src/components/TransactionForm/Migration/MigrateDAOForm.tsx
+++ b/packages/create-proposal-ui/src/components/TransactionForm/Migration/MigrateDAOForm.tsx
@@ -9,17 +9,17 @@ import { useState } from 'react'
 import { useReadContract } from 'wagmi'
 
 import { usePrepareMigration } from '../../../hooks/usePrepareMigration'
-import { type FormComponent } from '../types'
 
 const chainOptions = [{ label: 'Base', value: CHAIN_ID.BASE }]
 
-export const MigrateDAOForm: FormComponent = ({ resetTransactionType }) => {
+export const MigrateDAOForm: React.FC = () => {
   const { auction: auctionAddress } = useDaoStore((x) => x.addresses)
   const { id: chainId } = useChainStore((x) => x.chain)
   const [migratingToChainId, setMigratingToChainId] = useState<CHAIN_ID>(
     chainOptions[0].value
   )
   const addTransaction = useProposalStore((state) => state.addTransaction)
+  const resetTransactionType = useProposalStore((state) => state.resetTransactionType)
 
   const { data: auction } = useReadContract({
     abi: auctionAbi,

--- a/packages/create-proposal-ui/src/components/TransactionForm/Migration/Migration.tsx
+++ b/packages/create-proposal-ui/src/components/TransactionForm/Migration/Migration.tsx
@@ -8,7 +8,6 @@ import axios from 'axios'
 import useSWR from 'swr'
 import { useReadContract } from 'wagmi'
 
-import { type FormComponent } from '../types'
 import { BridgeTreasuryForm } from './BridgeTreasuryForm'
 import { MigrateDAOForm } from './MigrateDAOForm'
 import { MigrationTracker } from './MigrationTracker'
@@ -20,7 +19,7 @@ export enum DAOMigrationProgress {
   DEPLOYED = 2,
 }
 
-export const Migration: FormComponent = ({ resetTransactionType }) => {
+export const Migration: React.FC = () => {
   const chain = useChainStore((x) => x.chain)
   const {
     addresses: { treasury, auction },
@@ -48,15 +47,11 @@ export const Migration: FormComponent = ({ resetTransactionType }) => {
   else if (!deployed) daoProgress = DAOMigrationProgress.PAUSED
 
   const formComponents = [
-    <PauseAuctionsForm
-      key="pause-auctions-form"
-      resetTransactionType={resetTransactionType}
-    />,
-    <MigrateDAOForm key="migrate-dao-form" resetTransactionType={resetTransactionType} />,
+    <PauseAuctionsForm key="pause-auctions-form" />,
+    <MigrateDAOForm key="migrate-dao-form" />,
     <BridgeTreasuryForm
       migratedToChainId={migratedRes?.migrated?.chainId}
       key="bridge-treasury-form"
-      resetTransactionType={resetTransactionType}
     />,
   ]
 

--- a/packages/create-proposal-ui/src/components/TransactionForm/Migration/PauseAuctionsForm.tsx
+++ b/packages/create-proposal-ui/src/components/TransactionForm/Migration/PauseAuctionsForm.tsx
@@ -9,11 +9,11 @@ import { encodeFunctionData } from 'viem'
 import { useReadContract } from 'wagmi'
 
 import { checkboxStyleVariants } from '../ReplaceArtwork/ReplaceArtworkForm.css'
-import { type FormComponent } from '../types'
 
-export const PauseAuctionsForm: FormComponent = ({ resetTransactionType }) => {
+export const PauseAuctionsForm: React.FC = () => {
   const { auction, governor } = useDaoStore((state) => state.addresses)
   const addTransaction = useProposalStore((state) => state.addTransaction)
+  const resetTransactionType = useProposalStore((state) => state.resetTransactionType)
   const chain = useChainStore((x) => x.chain)
   const { data: paused } = useReadContract({
     abi: auctionAbi,

--- a/packages/create-proposal-ui/src/components/TransactionForm/MilestonePayments/MilestonePayments.tsx
+++ b/packages/create-proposal-ui/src/components/TransactionForm/MilestonePayments/MilestonePayments.tsx
@@ -19,7 +19,6 @@ import { useCallback, useState } from 'react'
 import useSWR from 'swr'
 import { Address, encodeFunctionData, formatUnits, isAddress, parseUnits } from 'viem'
 
-import { type FormComponent } from '../types'
 import { MilestonePaymentsFormValues } from './MilestonePayments.schema'
 import MilestonePaymentsForm from './MilestonePaymentsForm'
 import { encodeEscrowData } from './MilestonePaymentsUtils'
@@ -27,7 +26,8 @@ import { encodeEscrowData } from './MilestonePaymentsUtils'
 const LIMIT = 20
 const PAGE = 1
 
-export const MilestonePayments: FormComponent = ({ resetTransactionType }) => {
+export const MilestonePayments: React.FC = () => {
+  const resetTransactionType = useProposalStore((state) => state.resetTransactionType)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [ipfsUploadError, setIpfsUploadError] = useState<Error | null>(null)
 

--- a/packages/create-proposal-ui/src/components/TransactionForm/MintGovernanceTokens/MintGovernanceTokens.test.tsx
+++ b/packages/create-proposal-ui/src/components/TransactionForm/MintGovernanceTokens/MintGovernanceTokens.test.tsx
@@ -29,9 +29,7 @@ describe('MintGovernanceTokens', () => {
   })
 
   it('should render initially disabled mint-governance-tokens form given a required upgrade', async () => {
-    const resetTransactionType = vi.fn()
-
-    render(<MintGovernanceTokens resetTransactionType={resetTransactionType} />, {
+    render(<MintGovernanceTokens />, {
       chain: FOUNDRY_CHAIN,
       addresses: BUILDER_DAO,
     })
@@ -74,9 +72,5 @@ describe('MintGovernanceTokens', () => {
     })
     const amountAfterSubmit = screen.getByDisplayValue(0) as HTMLInputElement
     expect(amountAfterSubmit.value).toBe('0')
-
-    await waitFor(() => {
-      expect(resetTransactionType).toHaveBeenCalledTimes(1)
-    })
   })
 })

--- a/packages/create-proposal-ui/src/components/TransactionForm/MintGovernanceTokens/MintGovernanceTokens.tsx
+++ b/packages/create-proposal-ui/src/components/TransactionForm/MintGovernanceTokens/MintGovernanceTokens.tsx
@@ -8,21 +8,20 @@ import { getProvider } from '@buildeross/utils/provider'
 import { Stack, Text } from '@buildeross/zord'
 import { FormikHelpers } from 'formik'
 import gte from 'lodash/gte'
-import React from 'react'
 import { Address, encodeFunctionData, isAddress } from 'viem'
 import { useReadContract } from 'wagmi'
 
-import { FormComponent } from '../types'
 import { UpgradeInProgress, UpgradeRequired } from '../Upgrade'
 import MintGovernanceTokensForm from './MintGovernanceTokensForm'
 import { MintGovernanceTokensFormValues } from './MintGovernanceTokensForm.schema'
 
 const CONTRACT_VERSION = '1.2.0'
 
-export const MintGovernanceTokens: FormComponent = ({ resetTransactionType }) => {
+export const MintGovernanceTokens: React.FC = () => {
   const addresses = useDaoStore((state) => state.addresses)
   const transactions = useProposalStore((state) => state.transactions)
   const addTransaction = useProposalStore((state) => state.addTransaction)
+  const resetTransactionType = useProposalStore((state) => state.resetTransactionType)
   const chain = useChainStore((x) => x.chain)
 
   const {

--- a/packages/create-proposal-ui/src/components/TransactionForm/NominateEscrowDelegate/NominateEscrowDelegate.tsx
+++ b/packages/create-proposal-ui/src/components/TransactionForm/NominateEscrowDelegate/NominateEscrowDelegate.tsx
@@ -19,8 +19,6 @@ import { useCallback } from 'react'
 import { encodeFunctionData, getAddress, Hex, isAddress, zeroHash } from 'viem'
 import * as yup from 'yup'
 
-import { type FormComponent } from '../types'
-
 interface EscrowDelegateFormValues {
   escrowDelegate: string
 }
@@ -52,9 +50,10 @@ const escrowDelegateFormSchema = (_escrowDelegate: string | undefined) =>
 
 const schemaEncoder = new SchemaEncoder(ESCROW_DELEGATE_SCHEMA)
 
-export const NominateEscrowDelegate: FormComponent = ({ resetTransactionType }) => {
+export const NominateEscrowDelegate: React.FC = () => {
   const { token, treasury } = useDaoStore((state) => state.addresses)
   const addTransaction = useProposalStore((state) => state.addTransaction)
+  const resetTransactionType = useProposalStore((state) => state.resetTransactionType)
   const chain = useChainStore((x) => x.chain)
   const { escrowDelegate } = useEscrowDelegate({
     chainId: chain.id,

--- a/packages/create-proposal-ui/src/components/TransactionForm/PauseAuctions/PauseAuctions.tsx
+++ b/packages/create-proposal-ui/src/components/TransactionForm/PauseAuctions/PauseAuctions.tsx
@@ -6,11 +6,10 @@ import { useState } from 'react'
 import { encodeFunctionData } from 'viem'
 import { useReadContract } from 'wagmi'
 
-import { type FormComponent } from '../types'
-
-export const PauseAuctions: FormComponent = ({ resetTransactionType }) => {
+export const PauseAuctions: React.FC = () => {
   const { auction } = useDaoStore((state) => state.addresses)
   const addTransaction = useProposalStore((state) => state.addTransaction)
+  const resetTransactionType = useProposalStore((state) => state.resetTransactionType)
   const chain = useChainStore((x) => x.chain)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const { data: paused } = useReadContract({

--- a/packages/create-proposal-ui/src/components/TransactionForm/PinTreasuryAsset/PinTreasuryAsset.tsx
+++ b/packages/create-proposal-ui/src/components/TransactionForm/PinTreasuryAsset/PinTreasuryAsset.tsx
@@ -14,14 +14,14 @@ import { Formik } from 'formik'
 import { useCallback } from 'react'
 import { encodeFunctionData, getAddress, type Hex, zeroHash } from 'viem'
 
-import { type FormComponent } from '../types'
 import { pinTreasuryAssetSchema, PinTreasuryAssetValues } from './PinTreasuryAsset.schema'
 import { PinTreasuryAssetForm } from './PinTreasuryAssetForm'
 
 const schemaEncoder = new SchemaEncoder(TREASURY_ASSET_PIN_SCHEMA)
 
-export const PinTreasuryAsset: FormComponent = ({ resetTransactionType }) => {
+export const PinTreasuryAsset: React.FC = () => {
   const addTransaction = useProposalStore((state) => state.addTransaction)
+  const resetTransactionType = useProposalStore((state) => state.resetTransactionType)
   const { chain } = useChainStore()
   const { addresses } = useDaoStore()
 

--- a/packages/create-proposal-ui/src/components/TransactionForm/ReplaceArtwork/ReplaceArtwork.tsx
+++ b/packages/create-proposal-ui/src/components/TransactionForm/ReplaceArtwork/ReplaceArtwork.tsx
@@ -12,16 +12,16 @@ import useSWR from 'swr'
 import { encodeFunctionData } from 'viem'
 
 import { useArtworkStore } from '../../../stores/useArtworkStore'
-import { type FormComponent } from '../types'
 import { UpgradeInProgress, UpgradeRequired } from '../Upgrade'
 import { ReplaceArtworkForm } from './ReplaceArtworkForm'
 
 const REPLACE_ARTWORK_CONTRACT_VERSION = '1.2.0'
 
-export const ReplaceArtwork: FormComponent = ({ resetTransactionType }) => {
+export const ReplaceArtwork: React.FC = () => {
   const { orderedLayers, ipfsUpload, isUploadingToIPFS, resetForm } = useArtworkStore()
   const addresses = useDaoStore((x) => x.addresses)
   const addTransaction = useProposalStore((state) => state.addTransaction)
+  const resetTransactionType = useProposalStore((state) => state.resetTransactionType)
   const currentTransactions = useProposalStore((state) => state.transactions)
   const chain = useChainStore((x) => x.chain)
 

--- a/packages/create-proposal-ui/src/components/TransactionForm/ResumeAuctions/ResumeAuctions.tsx
+++ b/packages/create-proposal-ui/src/components/TransactionForm/ResumeAuctions/ResumeAuctions.tsx
@@ -6,11 +6,10 @@ import { useState } from 'react'
 import { encodeFunctionData } from 'viem'
 import { useReadContract } from 'wagmi'
 
-import { type FormComponent } from '../types'
-
-export const ResumeAuctions: FormComponent = ({ resetTransactionType }) => {
+export const ResumeAuctions: React.FC = () => {
   const { auction } = useDaoStore((state) => state.addresses)
   const addTransaction = useProposalStore((state) => state.addTransaction)
+  const resetTransactionType = useProposalStore((state) => state.resetTransactionType)
   const chain = useChainStore((x) => x.chain)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const { data: paused } = useReadContract({

--- a/packages/create-proposal-ui/src/components/TransactionForm/SendNft/SendNft.tsx
+++ b/packages/create-proposal-ui/src/components/TransactionForm/SendNft/SendNft.tsx
@@ -17,7 +17,6 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { encodeFunctionData, getAddress, isAddress } from 'viem'
 import { useReadContracts } from 'wagmi'
 
-import { type FormComponent } from '../types'
 import sendNftSchema, { SendNftValues } from './SendNft.schema'
 
 type NftOption = 'treasury-nfts' | 'custom' | string
@@ -454,8 +453,9 @@ const SendNftForm = ({ formik, onNftMetadataChange }: SendNftFormProps) => {
   )
 }
 
-export const SendNft: FormComponent = ({ resetTransactionType }) => {
+export const SendNft: React.FC = () => {
   const { treasury } = useDaoStore((state) => state.addresses)
+  const resetTransactionType = useProposalStore((state) => state.resetTransactionType)
   const chain = useChainStore((x) => x.chain)
   const addTransaction = useProposalStore((state) => state.addTransaction)
   const [currentNftMetadata, setCurrentNftMetadata] = useState<NftMetadata | null>(null)

--- a/packages/create-proposal-ui/src/components/TransactionForm/SendTokens/SendTokens.tsx
+++ b/packages/create-proposal-ui/src/components/TransactionForm/SendTokens/SendTokens.tsx
@@ -22,7 +22,6 @@ import {
 } from 'viem'
 
 import { CsvRecord, CsvUpload, TokenSelectionForm } from '../../shared'
-import { type FormComponent } from '../types'
 import sendTokensSchema, {
   RecipientFormValues,
   SendTokensValues,
@@ -31,8 +30,9 @@ import { SendTokensDetailsDisplay } from './SendTokensDetailsDisplay'
 
 const DECIMAL_REGEX = /^(\d+\.?\d*|\.\d+)$/
 
-export const SendTokens: FormComponent = ({ resetTransactionType }) => {
+export const SendTokens: React.FC = () => {
   const addTransaction = useProposalStore((state) => state.addTransaction)
+  const resetTransactionType = useProposalStore((state) => state.resetTransactionType)
   const chain = useChainStore((x) => x.chain)
   const [csvError, setCsvError] = useState<string>('')
 

--- a/packages/create-proposal-ui/src/components/TransactionForm/StreamTokens/StreamTokens.tsx
+++ b/packages/create-proposal-ui/src/components/TransactionForm/StreamTokens/StreamTokens.tsx
@@ -36,7 +36,6 @@ import {
 } from 'viem'
 
 import { TokenSelectionForm } from '../../shared'
-import { type FormComponent } from '../types'
 import { StreamForm } from './StreamForm'
 import streamTokensSchema, {
   StreamFormValues,
@@ -51,8 +50,9 @@ const truncateAddress = (addr: string) => {
   return snippet
 }
 
-export const StreamTokens: FormComponent = ({ resetTransactionType }) => {
+export const StreamTokens: React.FC = () => {
   const addTransaction = useProposalStore((state) => state.addTransaction)
+  const resetTransactionType = useProposalStore((state) => state.resetTransactionType)
   const { addresses } = useDaoStore()
   const chain = useChainStore((x) => x.chain)
 

--- a/packages/create-proposal-ui/src/components/TransactionForm/TransactionForm.tsx
+++ b/packages/create-proposal-ui/src/components/TransactionForm/TransactionForm.tsx
@@ -1,3 +1,4 @@
+import { useProposalStore } from '@buildeross/stores'
 import { TransactionType } from '@buildeross/types'
 
 import { AddArtwork } from './AddArtwork'
@@ -17,13 +18,7 @@ import { ResumeAuctions } from './ResumeAuctions'
 import { SendNft } from './SendNft'
 import { SendTokens } from './SendTokens'
 import { StreamTokens } from './StreamTokens'
-import { FormComponent, requireResetForm } from './types'
 import { WalletConnect } from './WalletConnect'
-
-interface TransactionFormProps {
-  transactionType: TransactionFormType
-  resetTransactionType: () => void
-}
 
 export type TransactionFormType = (typeof TRANSACTION_FORM_OPTIONS)[number]
 
@@ -48,32 +43,34 @@ export const TRANSACTION_FORM_OPTIONS = [
   TransactionType.MIGRATION,
 ] as const
 
-const FORMS: Record<TransactionFormType, FormComponent> = {
-  [TransactionType.CUSTOM]: requireResetForm(CustomTransaction),
-  [TransactionType.MINT_GOVERNANCE_TOKENS]: requireResetForm(MintGovernanceTokens),
-  [TransactionType.DROPOSAL]: requireResetForm(Droposal),
-  [TransactionType.SEND_NFT]: requireResetForm(SendNft),
-  [TransactionType.SEND_TOKENS]: requireResetForm(SendTokens),
-  [TransactionType.STREAM_TOKENS]: requireResetForm(StreamTokens),
-  [TransactionType.MILESTONE_PAYMENTS]: requireResetForm(MilestonePayments),
-  [TransactionType.NOMINATE_DELEGATE]: requireResetForm(NominateEscrowDelegate),
-  [TransactionType.WALLET_CONNECT]: requireResetForm(WalletConnect),
-  [TransactionType.PIN_TREASURY_ASSET]: requireResetForm(PinTreasuryAsset),
-  [TransactionType.PAUSE_AUCTIONS]: requireResetForm(PauseAuctions),
-  [TransactionType.FIX_RENDERER_BASE]: requireResetForm(FixRendererBase),
-  [TransactionType.RESUME_AUCTIONS]: requireResetForm(ResumeAuctions),
-  [TransactionType.ADD_ARTWORK]: requireResetForm(AddArtwork),
-  [TransactionType.REPLACE_ARTWORK]: requireResetForm(ReplaceArtwork),
-  [TransactionType.MIGRATION]: requireResetForm(Migration),
-  [TransactionType.CREATOR_COIN]: requireResetForm(CreatorCoin),
-  [TransactionType.CONTENT_COIN]: requireResetForm(ContentCoin),
+const FORMS: Record<TransactionFormType, React.FC> = {
+  [TransactionType.CUSTOM]: CustomTransaction,
+  [TransactionType.MINT_GOVERNANCE_TOKENS]: MintGovernanceTokens,
+  [TransactionType.DROPOSAL]: Droposal,
+  [TransactionType.SEND_NFT]: SendNft,
+  [TransactionType.SEND_TOKENS]: SendTokens,
+  [TransactionType.STREAM_TOKENS]: StreamTokens,
+  [TransactionType.MILESTONE_PAYMENTS]: MilestonePayments,
+  [TransactionType.NOMINATE_DELEGATE]: NominateEscrowDelegate,
+  [TransactionType.WALLET_CONNECT]: WalletConnect,
+  [TransactionType.PIN_TREASURY_ASSET]: PinTreasuryAsset,
+  [TransactionType.PAUSE_AUCTIONS]: PauseAuctions,
+  [TransactionType.FIX_RENDERER_BASE]: FixRendererBase,
+  [TransactionType.RESUME_AUCTIONS]: ResumeAuctions,
+  [TransactionType.ADD_ARTWORK]: AddArtwork,
+  [TransactionType.REPLACE_ARTWORK]: ReplaceArtwork,
+  [TransactionType.MIGRATION]: Migration,
+  [TransactionType.CREATOR_COIN]: CreatorCoin,
+  [TransactionType.CONTENT_COIN]: ContentCoin,
 } as const
 
-export const TransactionForm = ({
-  transactionType,
-  resetTransactionType,
-}: TransactionFormProps) => {
-  const Component: FormComponent = FORMS[transactionType]
+export const TransactionForm: React.FC = () => {
+  const transactionType = useProposalStore((state) => state.transactionType)
+  const Component = FORMS[transactionType as TransactionFormType]
 
-  return <Component resetTransactionType={resetTransactionType} />
+  if (!Component) {
+    return null
+  }
+
+  return <Component />
 }

--- a/packages/create-proposal-ui/src/components/TransactionForm/WalletConnect/WalletConnect.tsx
+++ b/packages/create-proposal-ui/src/components/TransactionForm/WalletConnect/WalletConnect.tsx
@@ -15,7 +15,6 @@ import {
   WCParams,
   WCPayload,
 } from '../../../hooks/useWalletConnect'
-import { type FormComponent } from '../types'
 import * as styles from './WalletConnect.css'
 import walletConnectSchema, { WalletConnectValues } from './WalletConnect.schema'
 
@@ -249,8 +248,9 @@ const TransactionPreview = ({ txPayload }: { txPayload: WCPayload }) => {
   )
 }
 
-export const WalletConnect: FormComponent = ({ resetTransactionType }) => {
+export const WalletConnect: React.FC = () => {
   const addTransaction = useProposalStore((state) => state.addTransaction)
+  const resetTransactionType = useProposalStore((state) => state.resetTransactionType)
   const [currentClientData, setCurrentClientData] = useState<WCClientData | null>(null)
   const [currentTxPayload, setCurrentTxPayload] = useState<WCPayload | null>(null)
 

--- a/packages/create-proposal-ui/src/components/TransactionForm/types.ts
+++ b/packages/create-proposal-ui/src/components/TransactionForm/types.ts
@@ -1,7 +1,0 @@
-import { type ReactNode } from 'react'
-
-export type FormComponentProps = { resetTransactionType: () => void }
-
-export type FormComponent = (props: FormComponentProps) => ReactNode
-
-export const requireResetForm = (c: FormComponent): FormComponent => c

--- a/packages/stores/src/hooks/useProposalStore.ts
+++ b/packages/stores/src/hooks/useProposalStore.ts
@@ -1,8 +1,10 @@
-import type { BuilderTransaction } from '@buildeross/types'
+import type { BuilderTransaction, TransactionType } from '@buildeross/types'
 import { create } from 'zustand'
 import { createJSONStorage, persist } from 'zustand/middleware'
 
 export type { BuilderTransaction }
+
+export type TransactionFormType = TransactionType
 
 export const PROPOSAL_STORE_IDENTIFIER = `nouns-builder-proposal-${process.env.NEXT_PUBLIC_NETWORK_TYPE}`
 
@@ -11,6 +13,7 @@ type State = {
   disabled: boolean
   title?: string
   summary?: string
+  transactionType: TransactionFormType | null
 }
 
 type Actions = {
@@ -25,6 +28,8 @@ type Actions = {
     transactions,
   }: Pick<State, 'title' | 'summary' | 'transactions' | 'disabled'>) => void
   clearProposal: () => void
+  setTransactionType: (type: TransactionFormType | null) => void
+  resetTransactionType: () => void
 }
 
 const initialState: State = {
@@ -32,6 +37,7 @@ const initialState: State = {
   title: undefined,
   disabled: false,
   transactions: [],
+  transactionType: null,
 }
 
 export const useProposalStore = create<State & Actions>()(
@@ -59,6 +65,8 @@ export const useProposalStore = create<State & Actions>()(
       createProposal: ({ title, summary, disabled, transactions }) =>
         set({ title, summary, disabled, transactions }),
       clearProposal: () => set(() => ({ ...initialState })),
+      setTransactionType: (type) => set({ transactionType: type }),
+      resetTransactionType: () => set({ transactionType: null }),
     }),
     {
       name: PROPOSAL_STORE_IDENTIFIER,
@@ -68,6 +76,7 @@ export const useProposalStore = create<State & Actions>()(
         disabled: state.disabled,
         title: state.title,
         summary: state.summary,
+        transactionType: state.transactionType,
       }),
     }
   )

--- a/packages/ui/src/SwapWidget/SwapWidget.tsx
+++ b/packages/ui/src/SwapWidget/SwapWidget.tsx
@@ -12,7 +12,7 @@ import { CHAIN_ID } from '@buildeross/types'
 import { formatPrice } from '@buildeross/utils/formatMarketCap'
 import { truncateHex } from '@buildeross/utils/helpers'
 import { Box, Button, Flex, Input, Text } from '@buildeross/zord'
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Address, erc20Abi, formatEther, parseEther } from 'viem'
 import {
   useAccount,
@@ -60,6 +60,14 @@ export const SwapWidget = ({ coinAddress, symbol, chainId }: SwapWidgetProps) =>
     coinAddress,
     isBuying
   )
+
+  useEffect(() => {
+    if (swapOptions.length === 0) return
+    const optionAddresses = swapOptions.map((o) => o.token.address.toLowerCase())
+    if (!optionAddresses.includes(selectedPaymentToken.toLowerCase())) {
+      setSelectedPaymentToken(swapOptions[0].token.address)
+    }
+  }, [swapOptions, selectedPaymentToken])
 
   // Get the selected swap option
   const selectedOption = swapOptions.find(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Proposal creation flow now uses shared state for transaction type, improving consistency: transaction type selection auto-resets if it becomes invalid and forms render reliably when a type is chosen.

* **Chores**
  * Prepared UI for a Sell tab in the swap widget (feature flagged off by default).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->