### PR TITLE
feat: use balance to display trade vs buy in button

### DIFF
--- a/apps/web/src/modules/coin/CoinDetail/CoinDetail.tsx
+++ b/apps/web/src/modules/coin/CoinDetail/CoinDetail.tsx
@@ -193,6 +193,9 @@ export const CoinDetail = ({
         shareUrl={shareUrl}
         isLoadingPrice={isLoadingPrice}
         onTradeClick={() => setIsMobileModalOpen(true)}
+        chainId={chainId}
+        coinAddress={coinAddress}
+        sellEnabled={sellEnabled}
       />
 
       {/* Mobile Trade Modal */}

--- a/packages/ui/src/MobileTradeBar/MobileTradeBar.tsx
+++ b/packages/ui/src/MobileTradeBar/MobileTradeBar.tsx
@@ -1,5 +1,8 @@
+import { CHAIN_ID } from '@buildeross/types'
 import { Button } from '@buildeross/zord'
-import React from 'react'
+import React, { useMemo } from 'react'
+import { Address } from 'viem'
+import { useAccount, useBalance } from 'wagmi'
 
 import { ShareButton } from '../ShareButton'
 import { mobileTradeBar, tradeButton } from './MobileTradeBar.css'
@@ -10,18 +13,45 @@ export interface MobileTradeBarProps {
   shareUrl: string | null
   isLoadingPrice?: boolean
   onTradeClick: () => void
+  chainId: CHAIN_ID
+  coinAddress: Address
+  sellEnabled?: boolean
 }
 
 export const MobileTradeBar: React.FC<MobileTradeBarProps> = ({
   symbol,
   shareUrl,
   onTradeClick,
+  chainId,
+  coinAddress,
+  sellEnabled = true,
 }) => {
+  const { address: userAddress } = useAccount()
+
+  // Get user's coin balance to determine if they can trade
+  // Only fetch balance if sellEnabled is true (otherwise we always show "Buy")
+  const { data: coinBalance } = useBalance({
+    address: userAddress,
+    token: coinAddress,
+    chainId,
+    query: {
+      enabled: !!userAddress && sellEnabled,
+    },
+  })
+
+  // Check if user owns any of this coin
+  const hasBalance = useMemo(() => {
+    return sellEnabled && coinBalance && coinBalance.value > 0n
+  }, [sellEnabled, coinBalance])
+
+  // Show "Trade" only if sellEnabled is true AND user has a balance
+  const buttonText = sellEnabled && hasBalance ? `Trade ${symbol}` : `Buy ${symbol}`
+
   return (
     <div className={mobileTradeBar}>
       {shareUrl && <ShareButton url={shareUrl} variant="outline" />}
       <Button onClick={onTradeClick} variant="primary" className={tradeButton}>
-        Trade {symbol}
+        {buttonText}
       </Button>
     </div>
   )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Trade buttons now dynamically display based on user's coin balance. When a user holds a coin, the "Trade" option appears; otherwise, it defaults to "Buy," offering more contextual trading choices across trading interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->