### PR TITLE
fix: change preset amounts + don't allow to like again

### DIFF
--- a/packages/dao-ui/src/components/Cards/CoinCard.tsx
+++ b/packages/dao-ui/src/components/Cards/CoinCard.tsx
@@ -8,7 +8,6 @@ import { LinkWrapper as Link } from '@buildeross/ui/LinkWrapper'
 import { MediaPreview } from '@buildeross/ui/MediaPreview'
 import { ShareButton } from '@buildeross/ui/ShareButton'
 import { StatBadge } from '@buildeross/ui/StatBadge'
-import { isChainIdSupportedByCoining } from '@buildeross/utils/coining'
 import { Box, Button, Flex, Text } from '@buildeross/zord'
 import React, { useMemo } from 'react'
 import { Address } from 'viem'
@@ -24,7 +23,7 @@ interface CoinCardProps {
   image?: string // This is the IPFS URI
   createdAt?: string
   isZoraCoin?: boolean
-  onTradeClick?: (coinAddress: Address, symbol: string, isZoraCoin: boolean) => void
+  onTradeClick: (coinAddress: Address, symbol: string, isZoraCoin: boolean) => void
   showTypeBadge?: boolean
   sellEnabled?: boolean
 }
@@ -66,9 +65,6 @@ export const CoinCard = ({
   const isNew = createdAt
     ? Date.now() / 1000 - parseInt(createdAt) < 7 * 24 * 60 * 60
     : false
-
-  // Only show Trade button for supported chains
-  const showTradeButton = isChainIdSupportedByCoining(chainId)
 
   const { address: userAddress } = useAccount()
 
@@ -172,35 +168,37 @@ export const CoinCard = ({
           </Flex>
 
           {/* Trade Button */}
-          {showTradeButton && (
-            <Flex
-              className={tradeButtonContainer}
-              direction="row"
-              align="center"
-              w="100%"
-              justify="space-between"
-              gap="x1"
-            >
-              {isZoraCoin && (
-                <LikeButton
-                  coinAddress={coinAddress}
-                  symbol={symbol}
-                  chainId={chainId as CHAIN_ID.BASE | CHAIN_ID.BASE_SEPOLIA}
-                  size="sm"
-                  variant="ghost"
-                />
-              )}
-              {shareUrl && <ShareButton url={shareUrl} size="sm" variant="ghost" />}
-              <Button
+          <Flex
+            className={tradeButtonContainer}
+            direction="row"
+            align="center"
+            w="100%"
+            justify="space-between"
+            gap="x1"
+            onClick={(e: React.MouseEvent) => {
+              e.preventDefault()
+              e.stopPropagation()
+            }}
+          >
+            {isZoraCoin && (
+              <LikeButton
+                coinAddress={coinAddress}
+                symbol={symbol}
+                chainId={chainId as CHAIN_ID.BASE | CHAIN_ID.BASE_SEPOLIA}
                 size="sm"
-                variant="primary"
-                style={{ flex: 1 }}
-                onClick={handleTradeClick}
-              >
-                {sellEnabled && hasBalance ? 'Trade' : 'Buy'}
-              </Button>
-            </Flex>
-          )}
+                variant="ghost"
+              />
+            )}
+            {shareUrl && <ShareButton url={shareUrl} size="sm" variant="ghost" />}
+            <Button
+              size="sm"
+              variant="primary"
+              style={{ flex: 1 }}
+              onClick={handleTradeClick}
+            >
+              {sellEnabled && hasBalance ? 'Trade' : 'Buy'}
+            </Button>
+          </Flex>
         </Box>
       </Link>
     </>

--- a/packages/dao-ui/src/components/Cards/DropCard.tsx
+++ b/packages/dao-ui/src/components/Cards/DropCard.tsx
@@ -18,7 +18,7 @@ interface DropCardProps {
   drop: DropItem
   chainId: CHAIN_ID
   showTypeBadge?: boolean
-  onMintClick?: (drop: DropItem) => void
+  onMintClick: (drop: DropItem) => void
 }
 
 export const DropCard = ({
@@ -38,8 +38,6 @@ export const DropCard = ({
   const isNew = drop.createdAt
     ? Date.now() / 1000 - parseInt(drop.createdAt) < 7 * 24 * 60 * 60
     : false
-
-  const showMintButton = !!onMintClick
 
   const handleMintClick = (e: React.MouseEvent) => {
     e.preventDefault()
@@ -129,32 +127,31 @@ export const DropCard = ({
           >
             {drop.name}
           </Text>
-          {!showMintButton && shareUrl && (
-            <ShareButton url={shareUrl} size="sm" variant="ghost" />
-          )}
         </Flex>
 
-        {showMintButton && (
-          <Flex
-            className={tradeButtonContainer}
-            direction="row"
-            align="center"
-            w="100%"
-            justify="space-between"
-            gap="x1"
+        <Flex
+          className={tradeButtonContainer}
+          direction="row"
+          align="center"
+          w="100%"
+          justify="space-between"
+          gap="x1"
+          onClick={(e: React.MouseEvent) => {
+            e.preventDefault()
+            e.stopPropagation()
+          }}
+        >
+          {shareUrl && <ShareButton url={shareUrl} size="sm" variant="ghost" />}
+          <Button
+            size="sm"
+            variant="primary"
+            style={{ flex: 1 }}
+            onClick={handleMintClick}
+            disabled={!saleActive}
           >
-            {shareUrl && <ShareButton url={shareUrl} size="sm" variant="ghost" />}
-            <Button
-              size="sm"
-              variant="primary"
-              style={{ flex: 1 }}
-              onClick={handleMintClick}
-              disabled={!saleActive}
-            >
-              {mintButtonText}
-            </Button>
-          </Flex>
-        )}
+            {mintButtonText}
+          </Button>
+        </Flex>
       </Box>
     </Link>
   )

--- a/packages/ui/src/LikeButton/LikeButton.tsx
+++ b/packages/ui/src/LikeButton/LikeButton.tsx
@@ -106,7 +106,7 @@ const LikeButton: React.FC<LikeButtonProps> = ({
         chainId={chainId}
         borderRadius="curved"
         size={size}
-        style={{ minWidth: 'unset' }}
+        style={{ minWidth: 'unset', opacity: 1, cursor: 'not-allowed' }}
         px={px}
         disabled={isLiked}
       >

--- a/packages/ui/src/LikeButton/LikePopupContent.tsx
+++ b/packages/ui/src/LikeButton/LikePopupContent.tsx
@@ -182,6 +182,7 @@ export const LikePopupContent: React.FC<LikePopupContentProps> = ({
         p="x1"
         style={{ minWidth: '180px' }}
         onClick={(e: React.MouseEvent) => {
+          e.preventDefault()
           e.stopPropagation()
         }}
       >
@@ -200,6 +201,7 @@ export const LikePopupContent: React.FC<LikePopupContentProps> = ({
         p="x1"
         style={{ minWidth: '180px' }}
         onClick={(e: React.MouseEvent) => {
+          e.preventDefault()
           e.stopPropagation()
         }}
       >
@@ -226,6 +228,7 @@ export const LikePopupContent: React.FC<LikePopupContentProps> = ({
         p="x1"
         style={{ minWidth: '180px' }}
         onClick={(e: React.MouseEvent) => {
+          e.preventDefault()
           e.stopPropagation()
         }}
       >
@@ -237,9 +240,11 @@ export const LikePopupContent: React.FC<LikePopupContentProps> = ({
             variant="ghost"
             size="xs"
             onClick={(e: React.MouseEvent) => {
+              e.preventDefault()
               e.stopPropagation()
               onClose()
             }}
+            px="x2"
           >
             Close
           </Button>

--- a/packages/zord/src/components/PopUp.tsx
+++ b/packages/zord/src/components/PopUp.tsx
@@ -129,6 +129,7 @@ export function PopUp({
               w="100vw"
               h="100vh"
               onClick={(e: React.MouseEvent) => {
+                e.preventDefault()
                 e.stopPropagation()
                 setOpenState(false)
               }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Trade action is now always visible and accessible on coin cards.
  * Mint action is now always visible and accessible on drop cards.
  * Like button shows clearer filled state and disables when already liked.
  * Preset USD amounts updated to 0.1, 0.5, 1.0 and labels use one-decimal formatting.
  * Click handling improved across buttons and popups to prevent unintended navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->