### PR TITLE
feat: support mainnet manager v2 upgrade proposal type

### DIFF
--- a/packages/dao-ui/src/components/Upgrade/ManagerV2Upgrade.tsx
+++ b/packages/dao-ui/src/components/Upgrade/ManagerV2Upgrade.tsx
@@ -1,0 +1,175 @@
+import { managerAbi } from '@buildeross/sdk/contract'
+import { useProposalStore } from '@buildeross/stores'
+import { AddressType, BuilderTransaction, TransactionType } from '@buildeross/types'
+import { UpgradeCard } from '@buildeross/ui/UpgradeCard'
+import { Flex, Text } from '@buildeross/zord'
+import dayjs from 'dayjs'
+import { AnimatePresence, motion } from 'framer-motion'
+import React from 'react'
+import { encodeFunctionData } from 'viem'
+
+import { default as summary } from './versions/manager-v2-upgrade.md'
+
+const MANAGER_PROXY = '0xd310a3041dfcf14def5ccbc508668974b5da7174' as AddressType
+const MANAGER_IMPL = '0xDaFeB89F713e25a02E4eC21A18e3757d7a76d19E' as AddressType
+const TOKEN_V1_1_0 = '0xe6322201ceD0a4D6595968411285A39ccf9d5989' as AddressType
+const TOKEN_V1_2_0 = '0xAeD75D1e5c1821E2EC29D5d24b794b13C34c5d63' as AddressType
+const TOKEN_NEW = '0x0E7bBc0123F5a9d6526c44D58273a8889D6F35b0' as AddressType
+const AUCTION_V1_1_0 = '0x2661fe1a882AbFD28AE0c2769a90F327850397c6' as AddressType
+const AUCTION_V1_2_0 = '0x785708d09b89C470aD7B5b3f8ac804cE72B6b282' as AddressType
+const AUCTION_NEW = '0x3c383f54a0024e840EB479f15926164d8f00e0A4' as AddressType
+const GOVERNOR_V1_1_0 = '0x9eefEF0891b1895af967fe48C5D7D96E984B96a3' as AddressType
+const GOVERNOR_V1_2_0 = '0x46eA3fd17DEb7B291AeA60E67E5cB3a104FEa11D' as AddressType
+const GOVERNOR_NEW = '0x6a6ec19CdB30E74Ea19a9e269d6Ca0dBAd92D4D1' as AddressType
+const NEW_MANAGER_OWNER = '0x6257eDA33CB66EdA10354ebCf6Ab49e9E7558739' as AddressType
+
+const getManagerV2UpgradeTransaction = (): BuilderTransaction => {
+  const transactions = [
+    {
+      functionSignature: 'upgradeTo(address)',
+      target: MANAGER_PROXY,
+      value: '',
+      calldata: encodeFunctionData({
+        abi: managerAbi,
+        functionName: 'upgradeTo',
+        args: [MANAGER_IMPL],
+      }),
+    },
+    {
+      functionSignature: 'registerUpgrade(address,address)',
+      target: MANAGER_PROXY,
+      value: '',
+      calldata: encodeFunctionData({
+        abi: managerAbi,
+        functionName: 'registerUpgrade',
+        args: [TOKEN_V1_1_0, TOKEN_NEW],
+      }),
+    },
+    {
+      functionSignature: 'registerUpgrade(address,address)',
+      target: MANAGER_PROXY,
+      value: '',
+      calldata: encodeFunctionData({
+        abi: managerAbi,
+        functionName: 'registerUpgrade',
+        args: [TOKEN_V1_2_0, TOKEN_NEW],
+      }),
+    },
+    {
+      functionSignature: 'registerUpgrade(address,address)',
+      target: MANAGER_PROXY,
+      value: '',
+      calldata: encodeFunctionData({
+        abi: managerAbi,
+        functionName: 'registerUpgrade',
+        args: [AUCTION_V1_1_0, AUCTION_NEW],
+      }),
+    },
+    {
+      functionSignature: 'registerUpgrade(address,address)',
+      target: MANAGER_PROXY,
+      value: '',
+      calldata: encodeFunctionData({
+        abi: managerAbi,
+        functionName: 'registerUpgrade',
+        args: [AUCTION_V1_2_0, AUCTION_NEW],
+      }),
+    },
+    {
+      functionSignature: 'registerUpgrade(address,address)',
+      target: MANAGER_PROXY,
+      value: '',
+      calldata: encodeFunctionData({
+        abi: managerAbi,
+        functionName: 'registerUpgrade',
+        args: [GOVERNOR_V1_1_0, GOVERNOR_NEW],
+      }),
+    },
+    {
+      functionSignature: 'registerUpgrade(address,address)',
+      target: MANAGER_PROXY,
+      value: '',
+      calldata: encodeFunctionData({
+        abi: managerAbi,
+        functionName: 'registerUpgrade',
+        args: [GOVERNOR_V1_2_0, GOVERNOR_NEW],
+      }),
+    },
+    {
+      functionSignature: 'safeTransferOwnership(address)',
+      target: MANAGER_PROXY,
+      value: '',
+      calldata: encodeFunctionData({
+        abi: managerAbi,
+        functionName: 'safeTransferOwnership',
+        args: [NEW_MANAGER_OWNER],
+      }),
+    },
+  ]
+
+  return {
+    type: TransactionType.UPGRADE,
+    summary: 'Manager contract upgrade to v2.0.0 with registered upgrade mappings',
+    transactions,
+  }
+}
+
+export const ManagerV2Upgrade = ({
+  hasThreshold,
+  onOpenProposalReview,
+}: {
+  hasThreshold: boolean
+  onOpenProposalReview: () => void
+}) => {
+  const startProposalDraft = useProposalStore((state) => state.startProposalDraft)
+
+  const handleUpgrade = (): void => {
+    startProposalDraft({
+      transactions: [getManagerV2UpgradeTransaction()],
+      disabled: true,
+      title: `Nouns Builder Manager Upgrade v2.0.0 ${dayjs().format('YYYY-MM-DD')}`,
+      summary,
+    })
+
+    onOpenProposalReview()
+  }
+
+  return (
+    <AnimatePresence>
+      <motion.div
+        initial={'init'}
+        animate={'open'}
+        variants={{
+          init: {
+            height: 0,
+            overflow: 'hidden',
+            transition: {
+              ease: 'easeInOut',
+            },
+          },
+          open: {
+            height: 'auto',
+            transition: {
+              ease: 'easeInOut',
+            },
+          },
+        }}
+      >
+        <Flex direction={'column'} mt={'x6'}>
+          <Text color="text3" mb={'x4'}>
+            Upgrade Available
+          </Text>
+          <UpgradeCard
+            version="- Manager Upgrade v2.0.0"
+            onUpgrade={handleUpgrade}
+            hasThreshold={hasThreshold}
+            description={
+              'Upgrade the Builder Manager contract to v2.0.0, register token/auction/governor 1.1 and 1.2 upgrade paths, and transfer manager ownership to the Gnosis Safe.'
+            }
+            totalContractUpgrades={8}
+          />
+        </Flex>
+      </motion.div>
+    </AnimatePresence>
+  )
+}

--- a/packages/dao-ui/src/components/Upgrade/ManagerV2Upgrade.tsx
+++ b/packages/dao-ui/src/components/Upgrade/ManagerV2Upgrade.tsx
@@ -1,0 +1,176 @@
+import { managerAbi } from '@buildeross/sdk/contract'
+import { useProposalStore } from '@buildeross/stores'
+import { AddressType, TransactionBundle, TransactionType } from '@buildeross/types'
+import { UpgradeCard } from '@buildeross/ui/UpgradeCard'
+import { Flex, Text } from '@buildeross/zord'
+import dayjs from 'dayjs'
+import { AnimatePresence, motion } from 'framer-motion'
+import React from 'react'
+import { encodeFunctionData } from 'viem'
+
+import { default as summary } from './versions/manager-v2-upgrade.md'
+
+const MANAGER_PROXY = '0xd310a3041dfcf14def5ccbc508668974b5da7174' as AddressType
+const MANAGER_IMPL = '0xDaFeB89F713e25a02E4eC21A18e3757d7a76d19E' as AddressType
+const TOKEN_V1_1_0 = '0xe6322201ceD0a4D6595968411285A39ccf9d5989' as AddressType
+const TOKEN_V1_2_0 = '0xAeD75D1e5c1821E2EC29D5d24b794b13C34c5d63' as AddressType
+const TOKEN_NEW = '0x0E7bBc0123F5a9d6526c44D58273a8889D6F35b0' as AddressType
+const AUCTION_V1_1_0 = '0x2661fe1a882AbFD28AE0c2769a90F327850397c6' as AddressType
+const AUCTION_V1_2_0 = '0x785708d09b89C470aD7B5b3f8ac804cE72B6b282' as AddressType
+const AUCTION_NEW = '0x3c383f54a0024e840EB479f15926164d8f00e0A4' as AddressType
+const GOVERNOR_V1_1_0 = '0x9eefEF0891b1895af967fe48C5D7D96E984B96a3' as AddressType
+const GOVERNOR_V1_2_0 = '0x46eA3fd17DEb7B291AeA60E67E5cB3a104FEa11D' as AddressType
+const GOVERNOR_NEW = '0x6a6ec19CdB30E74Ea19a9e269d6Ca0dBAd92D4D1' as AddressType
+const NEW_MANAGER_OWNER = '0x6257eDA33CB66EdA10354ebCf6Ab49e9E7558739' as AddressType
+
+const getManagerV2UpgradeTransaction = (): TransactionBundle => {
+  const transactions = [
+    {
+      functionSignature: 'upgradeTo(address)',
+      target: MANAGER_PROXY,
+      value: '',
+      calldata: encodeFunctionData({
+        abi: managerAbi,
+        functionName: 'upgradeTo',
+        args: [MANAGER_IMPL],
+      }),
+    },
+    {
+      functionSignature: 'registerUpgrade(address,address)',
+      target: MANAGER_PROXY,
+      value: '',
+      calldata: encodeFunctionData({
+        abi: managerAbi,
+        functionName: 'registerUpgrade',
+        args: [TOKEN_V1_1_0, TOKEN_NEW],
+      }),
+    },
+    {
+      functionSignature: 'registerUpgrade(address,address)',
+      target: MANAGER_PROXY,
+      value: '',
+      calldata: encodeFunctionData({
+        abi: managerAbi,
+        functionName: 'registerUpgrade',
+        args: [TOKEN_V1_2_0, TOKEN_NEW],
+      }),
+    },
+    {
+      functionSignature: 'registerUpgrade(address,address)',
+      target: MANAGER_PROXY,
+      value: '',
+      calldata: encodeFunctionData({
+        abi: managerAbi,
+        functionName: 'registerUpgrade',
+        args: [AUCTION_V1_1_0, AUCTION_NEW],
+      }),
+    },
+    {
+      functionSignature: 'registerUpgrade(address,address)',
+      target: MANAGER_PROXY,
+      value: '',
+      calldata: encodeFunctionData({
+        abi: managerAbi,
+        functionName: 'registerUpgrade',
+        args: [AUCTION_V1_2_0, AUCTION_NEW],
+      }),
+    },
+    {
+      functionSignature: 'registerUpgrade(address,address)',
+      target: MANAGER_PROXY,
+      value: '',
+      calldata: encodeFunctionData({
+        abi: managerAbi,
+        functionName: 'registerUpgrade',
+        args: [GOVERNOR_V1_1_0, GOVERNOR_NEW],
+      }),
+    },
+    {
+      functionSignature: 'registerUpgrade(address,address)',
+      target: MANAGER_PROXY,
+      value: '',
+      calldata: encodeFunctionData({
+        abi: managerAbi,
+        functionName: 'registerUpgrade',
+        args: [GOVERNOR_V1_2_0, GOVERNOR_NEW],
+      }),
+    },
+    {
+      functionSignature: 'safeTransferOwnership(address)',
+      target: MANAGER_PROXY,
+      value: '',
+      calldata: encodeFunctionData({
+        abi: managerAbi,
+        functionName: 'safeTransferOwnership',
+        args: [NEW_MANAGER_OWNER],
+      }),
+    },
+  ]
+
+  return {
+    type: TransactionType.UPGRADE,
+    title: `Upgrade Nouns Builder Manager to v2.0.0`,
+    summary: 'Manager contract upgrade to v2.0.0 with registered upgrade mappings',
+    transactions,
+  }
+}
+
+export const ManagerV2Upgrade = ({
+  hasThreshold,
+  onOpenProposalReview,
+}: {
+  hasThreshold: boolean
+  onOpenProposalReview: () => void
+}) => {
+  const startProposalDraft = useProposalStore((state) => state.startProposalDraft)
+
+  const handleUpgrade = (): void => {
+    startProposalDraft({
+      transactions: [getManagerV2UpgradeTransaction()],
+      disabled: true,
+      title: `Nouns Builder Manager Upgrade v2.0.0 ${dayjs().format('YYYY-MM-DD')}`,
+      summary,
+    })
+
+    onOpenProposalReview()
+  }
+
+  return (
+    <AnimatePresence>
+      <motion.div
+        initial={'init'}
+        animate={'open'}
+        variants={{
+          init: {
+            height: 0,
+            overflow: 'hidden',
+            transition: {
+              ease: 'easeInOut',
+            },
+          },
+          open: {
+            height: 'auto',
+            transition: {
+              ease: 'easeInOut',
+            },
+          },
+        }}
+      >
+        <Flex direction={'column'} mt={'x6'}>
+          <Text color="text3" mb={'x4'}>
+            Upgrade Available
+          </Text>
+          <UpgradeCard
+            version="- Manager Upgrade v2.0.0"
+            onUpgrade={handleUpgrade}
+            hasThreshold={hasThreshold}
+            description={
+              'Upgrade the Builder Manager contract to v2.0.0, register token/auction/governor 1.1 and 1.2 upgrade paths, and transfer manager ownership to the Gnosis Safe.'
+            }
+            totalContractUpgrades={8}
+          />
+        </Flex>
+      </motion.div>
+    </AnimatePresence>
+  )
+}

--- a/packages/dao-ui/src/components/Upgrade/Upgrade.tsx
+++ b/packages/dao-ui/src/components/Upgrade/Upgrade.tsx
@@ -1,5 +1,6 @@
 import { useAvailableUpgrade } from '@buildeross/hooks/useAvailableUpgrade'
 import { DaoContractAddresses, useChainStore, useProposalStore } from '@buildeross/stores'
+import { CHAIN_ID } from '@buildeross/types'
 import { UpgradeCard } from '@buildeross/ui/UpgradeCard'
 import { Flex, Text } from '@buildeross/zord'
 import dayjs from 'dayjs'
@@ -7,6 +8,7 @@ import { AnimatePresence, motion } from 'framer-motion'
 import React from 'react'
 
 import { FixRendererBase } from '../FixRendererBase'
+import { ManagerV2Upgrade } from './ManagerV2Upgrade'
 import { v1_1_0, v1_2_0, v2_0_0 } from './versions'
 
 export const VERSION_PROPOSAL_SUMMARY: { [key: string]: string } = {
@@ -28,6 +30,10 @@ export const Upgrade = ({
 }) => {
   const startProposalDraft = useProposalStore((state) => state.startProposalDraft)
   const chain = useChainStore((x) => x.chain)
+  const isManagerV2UpgradeDao =
+    chain.id === CHAIN_ID.ETHEREUM &&
+    collection.toLowerCase() === '0xdf9b7d26c8fc806b1ae6273684556761ff02d422' &&
+    addresses.treasury?.toLowerCase() === '0xdc9b96ea4966d063dd5c8dbaf08fe59062091b6d'
 
   const {
     latest,
@@ -43,9 +49,17 @@ export const Upgrade = ({
 
   if (!shouldUpgrade)
     return (
-      <FixRendererBase
-        {...{ hasThreshold, collection, addresses, onOpenProposalReview }}
-      />
+      <>
+        {isManagerV2UpgradeDao && (
+          <ManagerV2Upgrade
+            hasThreshold={hasThreshold}
+            onOpenProposalReview={onOpenProposalReview}
+          />
+        )}
+        <FixRendererBase
+          {...{ hasThreshold, collection, addresses, onOpenProposalReview }}
+        />
+      </>
     )
 
   const handleUpgrade = (): void => {
@@ -60,40 +74,48 @@ export const Upgrade = ({
   }
 
   return (
-    <AnimatePresence>
-      <motion.div
-        initial={'init'}
-        animate={'open'}
-        variants={{
-          init: {
-            height: 0,
-            overflow: 'hidden',
-            transition: {
-              ease: 'easeInOut',
+    <>
+      {isManagerV2UpgradeDao && (
+        <ManagerV2Upgrade
+          hasThreshold={hasThreshold}
+          onOpenProposalReview={onOpenProposalReview}
+        />
+      )}
+      <AnimatePresence>
+        <motion.div
+          initial={'init'}
+          animate={'open'}
+          variants={{
+            init: {
+              height: 0,
+              overflow: 'hidden',
+              transition: {
+                ease: 'easeInOut',
+              },
             },
-          },
-          open: {
-            height: 'auto',
-            transition: {
-              ease: 'easeInOut',
+            open: {
+              height: 'auto',
+              transition: {
+                ease: 'easeInOut',
+              },
             },
-          },
-        }}
-      >
-        <Flex direction={'column'} mt={'x6'}>
-          <Text color="text3" mb={'x4'}>
-            Upgrade Available
-          </Text>
-          <UpgradeCard
-            onUpgrade={handleUpgrade}
-            hasThreshold={hasThreshold}
-            version={latest}
-            date={date}
-            description={description}
-            totalContractUpgrades={totalContractUpgrades}
-          />
-        </Flex>
-      </motion.div>
-    </AnimatePresence>
+          }}
+        >
+          <Flex direction={'column'} mt={'x6'}>
+            <Text color="text3" mb={'x4'}>
+              Upgrade Available
+            </Text>
+            <UpgradeCard
+              onUpgrade={handleUpgrade}
+              hasThreshold={hasThreshold}
+              version={latest}
+              date={date}
+              description={description}
+              totalContractUpgrades={totalContractUpgrades}
+            />
+          </Flex>
+        </motion.div>
+      </AnimatePresence>
+    </>
   )
 }

--- a/packages/dao-ui/src/components/Upgrade/versions/manager-v2-upgrade.md
+++ b/packages/dao-ui/src/components/Upgrade/versions/manager-v2-upgrade.md
@@ -1,0 +1,29 @@
+## Summary
+
+This proposal upgrades the Builder Manager contract to v2.0.0.
+
+It upgrades the manager proxy, registers Token/Auction/Governor upgrade mappings for both 1.1.0 and 1.2.0 bases, and transfers manager ownership to the Gnosis Safe.
+
+### Auction Rewards Policy Update
+
+The new Auction implementation sets:
+
+- `builderRewardsBPS = 250` (2.5%)
+- `referralRewardsBPS = 250` (2.5%)
+
+For upgraded DAOs, settled auction proceeds route these splits through protocol rewards before the remainder is sent to treasury.
+
+### Included Calls
+
+1. `upgradeTo(address)` on Manager proxy
+2. `registerUpgrade(address,address)` for Token 1.1.0 -> new Token impl
+3. `registerUpgrade(address,address)` for Token 1.2.0 -> new Token impl
+4. `registerUpgrade(address,address)` for Auction 1.1.0 -> new Auction impl
+5. `registerUpgrade(address,address)` for Auction 1.2.0 -> new Auction impl
+6. `registerUpgrade(address,address)` for Governor 1.1.0 -> new Governor impl
+7. `registerUpgrade(address,address)` for Governor 1.2.0 -> new Governor impl
+8. `safeTransferOwnership(address)` to `0x6257eDA33CB66EdA10354ebCf6Ab49e9E7558739` (Gnosis Safe)
+
+### Notes
+
+MetadataRenderer and Treasury implementations are unchanged in this release.

--- a/packages/proposal-ui/src/components/ProposalDescription/ProposalDescription.tsx
+++ b/packages/proposal-ui/src/components/ProposalDescription/ProposalDescription.tsx
@@ -261,7 +261,7 @@ export const ProposalDescription: React.FC<ProposalDescriptionProps> = ({
           </Section>
         )}
 
-        <Section title="Proposer" mb={isPreview ? 'x0' : undefined}>
+        <Section title="Proposer">
           <Flex direction={'row'} placeItems={'center'}>
             <Box
               backgroundColor="background2"
@@ -307,15 +307,13 @@ export const ProposalDescription: React.FC<ProposalDescriptionProps> = ({
           </Flex>
         </Section>
 
-        {!isPreview && (
-          <Section title="Proposed Transactions">
-            <DecodedTransactions
-              decodedTransactions={decodedTransactions}
-              chainId={chain.id}
-              addresses={addresses}
-            />
-          </Section>
-        )}
+        <Section title="Proposed Transactions">
+          <DecodedTransactions
+            decodedTransactions={decodedTransactions}
+            chainId={chain.id}
+            addresses={addresses}
+          />
+        </Section>
       </Flex>
     </Flex>
   )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Manager V2 Upgrade capability to upgrade manager contracts and register upgrade mappings for Token, Auction, and Governor implementations.
  * Proposal descriptions now display decoded transaction details in preview mode.

* **Documentation**
  * Added guide documenting the Manager V2 Upgrade process, including contract ownership transfer and auction rewards policy configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->