### PR TITLE
fix: format milestone amounts without token symbol

### DIFF
--- a/packages/proposal-ui/src/components/ProposalDescription/MilestoneDetails/MilestoneItem.tsx
+++ b/packages/proposal-ui/src/components/ProposalDescription/MilestoneDetails/MilestoneItem.tsx
@@ -47,9 +47,10 @@ export const MilestoneItem = ({
   const isNext = currentMilestone === index
   const amount = milestoneAmounts?.[index] ?? 0n
   const decimals = tokenMetadata?.decimals ?? 18
+  const formattedAmount = formatCryptoVal(formatUnits(amount, decimals))
   const amountDisplay = tokenMetadata?.symbol
-    ? `${formatCryptoVal(formatUnits(amount, decimals))} ${tokenMetadata.symbol}`
-    : amount.toString()
+    ? `${formattedAmount} ${tokenMetadata.symbol}`
+    : formattedAmount
 
   const renderReleaseButton = () => {
     if (isReleased) {

--- a/packages/ui/src/DecodedTransactions/ArgumentDisplay/EscrowArgumentDisplay.tsx
+++ b/packages/ui/src/DecodedTransactions/ArgumentDisplay/EscrowArgumentDisplay.tsx
@@ -24,8 +24,10 @@ export const EscrowArgumentDisplay: React.FC<EscrowArgumentDisplayProps> = ({
 }) => {
   const formatAmount = useCallback(
     (amount: bigint) => {
-      if (!tokenMetadata) return amount.toString()
-      return `${formatCryptoVal(formatUnits(amount, tokenMetadata.decimals))} ${tokenMetadata.symbol}`
+      const decimals = tokenMetadata?.decimals ?? 18
+      const formatted = formatCryptoVal(formatUnits(amount, decimals))
+      if (!tokenMetadata) return formatted
+      return `${formatted} ${tokenMetadata.symbol}`
     },
     [tokenMetadata]
   )

--- a/packages/ui/src/DecodedTransactions/ArgumentDisplay/EscrowArgumentDisplay.tsx
+++ b/packages/ui/src/DecodedTransactions/ArgumentDisplay/EscrowArgumentDisplay.tsx
@@ -26,7 +26,7 @@ export const EscrowArgumentDisplay: React.FC<EscrowArgumentDisplayProps> = ({
     (amount: bigint) => {
       const decimals = tokenMetadata?.decimals ?? 18
       const formatted = formatCryptoVal(formatUnits(amount, decimals))
-      if (!tokenMetadata) return formatted
+      if (!tokenMetadata?.symbol) return formatted
       return `${formatted} ${tokenMetadata.symbol}`
     },
     [tokenMetadata]

--- a/packages/ui/src/DecodedTransactions/ArgumentDisplay/StreamArgumentDisplay.tsx
+++ b/packages/ui/src/DecodedTransactions/ArgumentDisplay/StreamArgumentDisplay.tsx
@@ -58,7 +58,7 @@ export const StreamArgumentDisplay: React.FC<StreamArgumentDisplayProps> = ({
     (amount: bigint) => {
       const decimals = tokenMetadata?.decimals ?? 18
       const formatted = formatCryptoVal(formatUnits(amount, decimals))
-      if (!tokenMetadata) return formatted
+      if (!tokenMetadata?.symbol) return formatted
       return `${formatted} ${tokenMetadata.symbol}`
     },
     [tokenMetadata]

--- a/packages/ui/src/DecodedTransactions/ArgumentDisplay/StreamArgumentDisplay.tsx
+++ b/packages/ui/src/DecodedTransactions/ArgumentDisplay/StreamArgumentDisplay.tsx
@@ -56,8 +56,10 @@ export const StreamArgumentDisplay: React.FC<StreamArgumentDisplayProps> = ({
 }) => {
   const formatAmount = useCallback(
     (amount: bigint) => {
-      if (!tokenMetadata) return amount.toString()
-      return `${formatCryptoVal(formatUnits(amount, tokenMetadata.decimals))} ${tokenMetadata.symbol}`
+      const decimals = tokenMetadata?.decimals ?? 18
+      const formatted = formatCryptoVal(formatUnits(amount, decimals))
+      if (!tokenMetadata) return formatted
+      return `${formatted} ${tokenMetadata.symbol}`
     },
     [tokenMetadata]
   )


### PR DESCRIPTION
## Summary

Fixes milestone amounts displaying as raw bigint values when token symbol is unavailable.

### Changes

- **MilestoneItem.tsx**: Fixed amount display to always use `formatCryptoVal()` with proper decimal formatting
- **EscrowArgumentDisplay.tsx**: Same fix for escrow milestone amounts  
- **StreamArgumentDisplay.tsx**: Same fix for stream amounts

### Before

When `tokenMetadata.symbol` was undefined, amounts showed as raw bigint

### After

Amounts are always formatted with default 18 decimals fallback

## Related

Closes #936


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consistent token amount formatting across proposal and transaction views: amounts are now always converted and formatted numerically (using a sensible default decimal precision when metadata is missing) and the token symbol is appended only when available.
  * Minor performance improvement by reusing the computed formatted amount to avoid redundant formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->