### PR TITLE
feat: added the missing timelockDelay field to Step2_ReviewConfig

### DIFF
--- a/packages/create-proposal-ui/src/components/TransactionForm/CrossChainMigration/Step2_ReviewConfig.schema.ts
+++ b/packages/create-proposal-ui/src/components/TransactionForm/CrossChainMigration/Step2_ReviewConfig.schema.ts
@@ -22,9 +22,11 @@ export interface Step2ConfigFormValues {
   proposalUpdatablePeriod?: TimeStructure
   votingDelay: TimeStructure
   votingPeriod: TimeStructure
+  timelockDelay: TimeStructure
 }
 
 const twentyFourWeeks = 60 * 60 * 24 * 7 * 24
+const fiveMinutes = 60 * 5
 
 export const step2ConfigValidationSchema = (isV3OrHigher: boolean) =>
   Yup.object().shape({
@@ -68,6 +70,10 @@ export const step2ConfigValidationSchema = (isV3OrHigher: boolean) =>
     ),
     votingPeriod: durationValidationSchema(
       { value: 600, description: '10 minutes' },
+      { value: twentyFourWeeks, description: '24 weeks' }
+    ),
+    timelockDelay: durationValidationSchema(
+      { value: fiveMinutes, description: '5 minutes' },
       { value: twentyFourWeeks, description: '24 weeks' }
     ),
     ...(isV3OrHigher && {

--- a/packages/create-proposal-ui/src/components/TransactionForm/CrossChainMigration/Step2_ReviewConfig.tsx
+++ b/packages/create-proposal-ui/src/components/TransactionForm/CrossChainMigration/Step2_ReviewConfig.tsx
@@ -62,6 +62,7 @@ export const Step2_ReviewConfig: React.FC = () => {
         votingDelay: { days: 0, hours: 0, minutes: 0, seconds: 0 },
         votingPeriod: { days: 0, hours: 0, minutes: 0, seconds: 0 },
         proposalUpdatablePeriod: { days: 0, hours: 0, minutes: 0, seconds: 0 },
+        timelockDelay: { days: 0, hours: 0, minutes: 0, seconds: 0 },
       }
     }
 
@@ -84,6 +85,11 @@ export const Step2_ReviewConfig: React.FC = () => {
         typeof config.proposalUpdatablePeriod === 'bigint'
           ? config.proposalUpdatablePeriod
           : 0n
+      ),
+      timelockDelay: bigIntSecondsToTimeStructure(
+        typeof config.timelockDelay === 'bigint' && config.timelockDelay >= 300n
+          ? config.timelockDelay
+          : 300n
       ),
     }
   }, [sourceConfig, editedConfig])
@@ -148,6 +154,7 @@ export const Step2_ReviewConfig: React.FC = () => {
         quorumThresholdBps: values.quorumThresholdBps,
         votingDelay: timeStructureToBigIntSeconds(values.votingDelay),
         votingPeriod: timeStructureToBigIntSeconds(values.votingPeriod),
+        timelockDelay: timeStructureToBigIntSeconds(values.timelockDelay),
         proposalUpdatablePeriod: isV3OrHigher
           ? timeStructureToBigIntSeconds(values.proposalUpdatablePeriod!)
           : undefined,
@@ -603,6 +610,17 @@ export const Step2_ReviewConfig: React.FC = () => {
                       formik={formik}
                       errorMessage={formik.errors.votingPeriod}
                       helperText="How long a proposal remains open for voting"
+                      marginBottom="x4"
+                    />
+
+                    <DaysHoursMinsSecs
+                      id="timelockDelay"
+                      value={formik.values.timelockDelay}
+                      inputLabel="Timelock Delay"
+                      onChange={() => {}}
+                      formik={formik}
+                      errorMessage={formik.errors.timelockDelay}
+                      helperText="Delay between when a passed proposal is queued and when it can be executed"
                       marginBottom="x4"
                     />
                   </Stack>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable **Timelock Delay** field to the cross-chain migration Step 2 review form.
  * Users can set the delay from **5 minutes up to 24 weeks**, with input validation and inline error messaging.
  * The selected timelock delay is persisted with the saved migration configuration and shown in the Governance Settings UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->