### PR TITLE
feat: add backwards compatibility for base mainnet subgraph

### DIFF
--- a/apps/web/src/pages/dao/[network]/[token]/vote/[id].tsx
+++ b/apps/web/src/pages/dao/[network]/[token]/vote/[id].tsx
@@ -1,5 +1,6 @@
 import { CACHE_TIMES } from '@buildeross/constants/cacheTimes'
 import { PUBLIC_DEFAULT_CHAINS } from '@buildeross/constants/chains'
+import { supportsUpdatableProposals } from '@buildeross/constants/subgraph'
 import { SWR_KEYS } from '@buildeross/constants/swrKeys'
 import { SectionHandler } from '@buildeross/dao-ui'
 import {
@@ -276,12 +277,20 @@ export const getServerSideProps: GetServerSideProps = async ({ params, req, res 
         dao: collection.toLowerCase(),
       }
 
-  const data = await SubgraphSDK.connect(chain.id)
-    .proposalOGMetadata({
-      where,
-      first: 1,
-    })
-    .then((x) => (x.proposals.length > 0 ? x.proposals[0] : undefined))
+  const sdk = SubgraphSDK.connect(chain.id)
+  const data = supportsUpdatableProposals(chain.id)
+    ? await sdk
+        .proposalOGMetadataUpdatable({
+          where,
+          first: 1,
+        })
+        .then((x) => (x.proposals.length > 0 ? x.proposals[0] : undefined))
+    : await sdk
+        .proposalOGMetadata({
+          where,
+          first: 1,
+        })
+        .then((x) => (x.proposals.length > 0 ? x.proposals[0] : undefined))
 
   if (!data) {
     return {
@@ -313,8 +322,13 @@ export const getServerSideProps: GetServerSideProps = async ({ params, req, res 
   }
 
   // Redirect to latest version if this proposal has been replaced
-  if (proposal.state === ProposalState.Replaced && data.replacedBy) {
-    const latestProposalNumber = data.replacedBy.proposalNumber
+  if (
+    proposal.state === ProposalState.Replaced &&
+    'replacedBy' in data &&
+    data.replacedBy
+  ) {
+    const latestProposalNumber = (data.replacedBy as { proposalNumber: number })
+      .proposalNumber
 
     return {
       redirect: {

--- a/packages/constants/src/subgraph.ts
+++ b/packages/constants/src/subgraph.ts
@@ -13,12 +13,13 @@ export const PUBLIC_SUBGRAPH_URL: Map<CHAIN_ID, string> = new Map([
   [CHAIN_ID.ETHEREUM, createSubgraphUrl('nouns-builder-ethereum-mainnet')],
   [CHAIN_ID.SEPOLIA, createSubgraphUrl('nouns-builder-ethereum-sepolia')],
   [CHAIN_ID.OPTIMISM, createSubgraphUrl('nouns-builder-optimism-mainnet')],
-  [
-    CHAIN_ID.OPTIMISM_SEPOLIA,
-    createSubgraphUrl('nouns-builder-optimism-sepolia'),
-  ],
+  [CHAIN_ID.OPTIMISM_SEPOLIA, createSubgraphUrl('nouns-builder-optimism-sepolia')],
   [CHAIN_ID.BASE, createSubgraphUrl('nouns-builder-base-mainnet')],
   [CHAIN_ID.BASE_SEPOLIA, createSubgraphUrl('nouns-builder-base-sepolia')],
   [CHAIN_ID.ZORA, createSubgraphUrl('nouns-builder-zora-mainnet')],
   [CHAIN_ID.FOUNDRY, ''],
 ])
+
+export const supportsUpdatableProposals = (chainId: CHAIN_ID): boolean => {
+  return chainId !== CHAIN_ID.BASE
+}

--- a/packages/constants/src/subgraph.ts
+++ b/packages/constants/src/subgraph.ts
@@ -11,14 +11,14 @@ const createSubgraphUrl = (name: string, version = VERSION): string =>
 
 export const PUBLIC_SUBGRAPH_URL: Map<CHAIN_ID, string> = new Map([
   [CHAIN_ID.ETHEREUM, createSubgraphUrl('nouns-builder-ethereum-mainnet')],
-  [CHAIN_ID.SEPOLIA, createSubgraphUrl('nouns-builder-ethereum-sepolia', '0.1.17')],
+  [CHAIN_ID.SEPOLIA, createSubgraphUrl('nouns-builder-ethereum-sepolia')],
   [CHAIN_ID.OPTIMISM, createSubgraphUrl('nouns-builder-optimism-mainnet')],
   [
     CHAIN_ID.OPTIMISM_SEPOLIA,
-    createSubgraphUrl('nouns-builder-optimism-sepolia', '0.1.17'),
+    createSubgraphUrl('nouns-builder-optimism-sepolia'),
   ],
   [CHAIN_ID.BASE, createSubgraphUrl('nouns-builder-base-mainnet')],
-  [CHAIN_ID.BASE_SEPOLIA, createSubgraphUrl('nouns-builder-base-sepolia', '0.1.17')],
+  [CHAIN_ID.BASE_SEPOLIA, createSubgraphUrl('nouns-builder-base-sepolia')],
   [CHAIN_ID.ZORA, createSubgraphUrl('nouns-builder-zora-mainnet')],
   [CHAIN_ID.FOUNDRY, ''],
 ])

--- a/packages/proposal-ui/src/components/ProposalActions/VoteStatus/VoteStatus.test.tsx
+++ b/packages/proposal-ui/src/components/ProposalActions/VoteStatus/VoteStatus.test.tsx
@@ -67,6 +67,7 @@ describe('VoteStatus', () => {
             reason: 'FOR',
             support: Support.For,
             weight: 3,
+            timestamp: 1630000100,
           }}
           votesAvailable={1}
           proposalId={'0x12'}
@@ -91,6 +92,7 @@ describe('VoteStatus', () => {
             reason: '',
             support: Support.Against,
             weight: 5,
+            timestamp: 1630000100,
           }}
           votesAvailable={1}
           proposalId={'0x12'}
@@ -115,6 +117,7 @@ describe('VoteStatus', () => {
             reason: '',
             support: Support.Abstain,
             weight: 5,
+            timestamp: 1630000100,
           }}
           votesAvailable={1}
           proposalId={'0x12'}

--- a/packages/proposal-ui/src/components/ProposalActions/VoteStatus/VoteStatus.tsx
+++ b/packages/proposal-ui/src/components/ProposalActions/VoteStatus/VoteStatus.tsx
@@ -34,7 +34,7 @@ interface VoteStatusProps {
   title: string
   daoName?: string
   signerVote?: ProposalVote
-  updateDeadline?: number
+  updateDeadline?: number | null
   candidateVersion?: unknown | null
 }
 
@@ -94,6 +94,7 @@ export const VoteStatus: React.FC<VoteStatusProps> = ({
           support: valueToSupport[Number(support) as SupportValue],
           weight: Number(weight),
           reason,
+          timestamp: Math.floor(Date.now() / 1000),
         }
 
         setVote(eventVote)

--- a/packages/sdk/src/subgraph/fragments/Proposal.graphql
+++ b/packages/sdk/src/subgraph/fragments/Proposal.graphql
@@ -26,33 +26,8 @@ fragment Proposal on Proposal {
   executionTransactionHash
   vetoTransactionHash
   cancelTransactionHash
-  updatePeriodEnd
-  updateMessage
-  updateCount
   dao {
     governorAddress
     tokenAddress
-  }
-  candidateVersion {
-    candidateId
-    proposalHash
-    attestationUID
-    proposal {
-      id
-      proposalId
-      proposalNumber
-    }
-    versionNumber
-    group {
-      candidateNumber
-    }
-  }
-  replaces {
-    proposalId
-    proposalNumber
-  }
-  replacedBy {
-    proposalId
-    proposalNumber
   }
 }

--- a/packages/sdk/src/subgraph/fragments/ProposalDetailUpdatable.graphql
+++ b/packages/sdk/src/subgraph/fragments/ProposalDetailUpdatable.graphql
@@ -1,0 +1,4 @@
+fragment ProposalDetailUpdatable on Proposal {
+  ...ProposalUpdatable
+  metadata
+}

--- a/packages/sdk/src/subgraph/fragments/ProposalUpdatable.graphql
+++ b/packages/sdk/src/subgraph/fragments/ProposalUpdatable.graphql
@@ -1,0 +1,28 @@
+fragment ProposalUpdatable on Proposal {
+  ...Proposal
+  updatePeriodEnd
+  updateMessage
+  updateCount
+  candidateVersion {
+    candidateId
+    proposalHash
+    attestationUID
+    proposal {
+      id
+      proposalId
+      proposalNumber
+    }
+    versionNumber
+    group {
+      candidateNumber
+    }
+  }
+  replaces {
+    proposalId
+    proposalNumber
+  }
+  replacedBy {
+    proposalId
+    proposalNumber
+  }
+}

--- a/packages/sdk/src/subgraph/queries/daosForDashbaordUpdatable.graphql
+++ b/packages/sdk/src/subgraph/queries/daosForDashbaordUpdatable.graphql
@@ -1,0 +1,32 @@
+query daosForDashboardUpdatable($user: Bytes!, $first: Int, $skip: Int) {
+  daos(
+    where: { or: [{ voters_: { voter: $user } }, { owners_: { owner: $user } }] }
+    first: $first
+    skip: $skip
+  ) {
+    ...DAO
+    contractImage
+    auctionConfig {
+      minimumBidIncrement
+      reservePrice
+    }
+    proposals(
+      where: { executed_not: true, canceled_not: true, vetoed_not: true, replacedBy: null }
+      first: 10
+      skip: 0
+      orderBy: proposalNumber
+      orderDirection: desc
+    ) {
+      ...ProposalUpdatable
+      voteEnd
+      voteStart
+      expiresAt
+      votes {
+        voter
+      }
+    }
+    currentAuction {
+      ...CurrentAuction
+    }
+  }
+}

--- a/packages/sdk/src/subgraph/queries/proposalOGMetadataUpdatable.graphql
+++ b/packages/sdk/src/subgraph/queries/proposalOGMetadataUpdatable.graphql
@@ -1,0 +1,17 @@
+query proposalOGMetadataUpdatable($where: Proposal_filter!, $first: Int!) {
+  proposals(where: $where, first: $first) {
+    ...ProposalDetailUpdatable
+    votes {
+      ...ProposalVote
+    }
+    dao {
+      name
+      contractImage
+      tokenAddress
+      metadataAddress
+      auctionAddress
+      treasuryAddress
+      governorAddress
+    }
+  }
+}

--- a/packages/sdk/src/subgraph/queries/proposalUpdatable.graphql
+++ b/packages/sdk/src/subgraph/queries/proposalUpdatable.graphql
@@ -1,0 +1,8 @@
+query proposalUpdatable($proposalId: ID!) {
+  proposal(id: $proposalId) {
+    ...ProposalDetailUpdatable
+    votes {
+      ...ProposalVote
+    }
+  }
+}

--- a/packages/sdk/src/subgraph/queries/proposalVersions.graphql
+++ b/packages/sdk/src/subgraph/queries/proposalVersions.graphql
@@ -1,7 +1,7 @@
 query proposalVersions($where: Proposal_filter) {
   proposals(
     where: $where
-    orderBy: updateCount
+    orderBy: proposalNumber
     orderDirection: asc
   ) {
     ...Proposal

--- a/packages/sdk/src/subgraph/queries/proposalVersionsUpdatable.graphql
+++ b/packages/sdk/src/subgraph/queries/proposalVersionsUpdatable.graphql
@@ -1,0 +1,9 @@
+query proposalVersionsUpdatable($where: Proposal_filter) {
+  proposals(
+    where: $where
+    orderBy: updateCount
+    orderDirection: asc
+  ) {
+    ...ProposalUpdatable
+  }
+}

--- a/packages/sdk/src/subgraph/queries/proposalsUpdatable.graphql
+++ b/packages/sdk/src/subgraph/queries/proposalsUpdatable.graphql
@@ -1,0 +1,14 @@
+query proposalsUpdatable($where: Proposal_filter, $first: Int!, $skip: Int) {
+  proposals(
+    where: $where
+    first: $first
+    skip: $skip
+    orderBy: timeCreated
+    orderDirection: desc
+  ) {
+    ...ProposalUpdatable
+    votes {
+      ...ProposalVote
+    }
+  }
+}

--- a/packages/sdk/src/subgraph/requests/dashboardQuery.ts
+++ b/packages/sdk/src/subgraph/requests/dashboardQuery.ts
@@ -1,11 +1,17 @@
-import { PUBLIC_DEFAULT_CHAINS } from '@buildeross/constants'
+import { PUBLIC_DEFAULT_CHAINS, supportsUpdatableProposals } from '@buildeross/constants'
 import { CHAIN_ID } from '@buildeross/types'
 import { isAddress } from 'viem'
 
 import { SDK } from '../client'
-import type { DaosForDashboardQuery } from '../sdk.generated'
+import type {
+  DaosForDashboardQuery,
+  DaosForDashboardUpdatableQuery,
+} from '../sdk.generated'
 
-export type DashboardDao = DaosForDashboardQuery['daos'][number] & {
+export type DashboardDao = (
+  | DaosForDashboardQuery['daos'][number]
+  | DaosForDashboardUpdatableQuery['daos'][number]
+) & {
   chainId: CHAIN_ID
 }
 
@@ -21,14 +27,22 @@ export const dashboardRequest = async (
       throw new Error('Zero address not allowed')
 
     const data = await Promise.all(
-      PUBLIC_DEFAULT_CHAINS.map((chain) =>
-        SDK.connect(chain.id)
-          .daosForDashboard({
-            user: memberAddress.toLowerCase(),
-            first: 30,
-          })
-          .then((x) => ({ ...x, chainId: chain.id }))
-      )
+      PUBLIC_DEFAULT_CHAINS.map((chain) => {
+        const sdk = SDK.connect(chain.id)
+        return supportsUpdatableProposals(chain.id)
+          ? sdk
+              .daosForDashboardUpdatable({
+                user: memberAddress.toLowerCase(),
+                first: 30,
+              })
+              .then((x) => ({ ...x, chainId: chain.id }))
+          : sdk
+              .daosForDashboard({
+                user: memberAddress.toLowerCase(),
+                first: 30,
+              })
+              .then((x) => ({ ...x, chainId: chain.id }))
+      })
     )
 
     return data

--- a/packages/sdk/src/subgraph/requests/proposalQuery.ts
+++ b/packages/sdk/src/subgraph/requests/proposalQuery.ts
@@ -1,15 +1,18 @@
+import { supportsUpdatableProposals } from '@buildeross/constants'
 import { CHAIN_ID } from '@buildeross/types'
 
 import { getProposalState, ProposalState } from '../../contract/requests/getProposalState'
 import { SDK } from '../client'
 import {
   ProposalDetailFragment,
+  ProposalDetailUpdatableFragment,
   ProposalFragment,
+  ProposalUpdatableFragment,
   ProposalVoteFragment as ProposalVote,
 } from '../sdk.generated'
 
 export type Proposal = Omit<
-  ProposalDetailFragment,
+  ProposalDetailFragment | ProposalDetailUpdatableFragment,
   | 'transactionHash'
   | 'executionTransactionHash'
   | 'cancelTransactionHash'
@@ -21,6 +24,11 @@ export type Proposal = Omit<
   | 'executedAt'
   | 'proposer'
   | 'updatePeriodEnd'
+  | 'updateMessage'
+  | 'updateCount'
+  | 'candidateVersion'
+  | 'replaces'
+  | 'replacedBy'
 > & {
   proposer: string
   values: string[]
@@ -33,24 +41,27 @@ export type Proposal = Omit<
   executableFrom?: number
   expiresAt?: number
   executedAt?: number
-  updatePeriodEnd?: number
+  updatePeriodEnd?: number | null
+  updateMessage?: string | null
+  updateCount?: number | null
+  candidateVersion?: ProposalDetailUpdatableFragment['candidateVersion'] | null
+  replaces?: ProposalDetailUpdatableFragment['replaces'] | null
+  replacedBy?: ProposalDetailUpdatableFragment['replacedBy'] | null
   votes?: ProposalVote[]
 }
 
 export const formatAndFetchState = async (
   chainId: CHAIN_ID,
-  data: ProposalFragment | ProposalDetailFragment
+  data:
+    | ProposalFragment
+    | ProposalDetailFragment
+    | ProposalUpdatableFragment
+    | ProposalDetailUpdatableFragment
 ) => {
-  const {
-    executableFrom,
-    expiresAt,
-    calldatas,
-    executionTransactionHash,
-    updatePeriodEnd,
-    ...proposal
-  } = data
+  const { executableFrom, expiresAt, calldatas, executionTransactionHash, ...proposal } =
+    data
 
-  const baseProposal = {
+  const baseProposal: any = {
     ...proposal,
     calldatas: calldatas ? calldatas.split(':') : [],
     state: await getProposalState(
@@ -58,8 +69,20 @@ export const formatAndFetchState = async (
       proposal.dao.governorAddress,
       proposal.proposalId
     ),
-    updatePeriodEnd: updatePeriodEnd ? Number(updatePeriodEnd) : undefined,
   }
+
+  // Add updatable proposal fields (v0.1.17+) with explicit defaults (null, not undefined)
+  baseProposal.updatePeriodEnd =
+    'updatePeriodEnd' in data && data.updatePeriodEnd
+      ? Number(data.updatePeriodEnd)
+      : null
+  baseProposal.updateMessage =
+    'updateMessage' in data ? (data.updateMessage ?? null) : null
+  baseProposal.updateCount = 'updateCount' in data ? (data.updateCount ?? null) : null
+  baseProposal.candidateVersion =
+    'candidateVersion' in data ? (data.candidateVersion ?? null) : null
+  baseProposal.replaces = 'replaces' in data ? (data.replaces ?? null) : null
+  baseProposal.replacedBy = 'replacedBy' in data ? (data.replacedBy ?? null) : null
 
   // executableFrom and expiresAt will always either be both defined, or neither defined
   if (executableFrom && expiresAt) {
@@ -78,9 +101,10 @@ export const getProposal = async (
   proposalId: string
 ): Promise<Proposal | undefined> => {
   try {
-    const data = await SDK.connect(chainId).proposal({
-      proposalId: proposalId.toLowerCase(),
-    })
+    const sdk = SDK.connect(chainId)
+    const data = supportsUpdatableProposals(chainId)
+      ? await sdk.proposalUpdatable({ proposalId: proposalId.toLowerCase() })
+      : await sdk.proposal({ proposalId: proposalId.toLowerCase() })
 
     return await formatAndFetchState(chainId, data.proposal!)
   } catch (e) {

--- a/packages/sdk/src/subgraph/requests/proposalVersionsQuery.ts
+++ b/packages/sdk/src/subgraph/requests/proposalVersionsQuery.ts
@@ -1,18 +1,33 @@
+import { supportsUpdatableProposals } from '@buildeross/constants'
 import { CHAIN_ID } from '@buildeross/types'
 
 import { getProposalState, ProposalState } from '../../contract/requests/getProposalState'
 import { SDK } from '../client'
-import { ProposalFragment } from '../sdk.generated'
+import { ProposalFragment, ProposalUpdatableFragment } from '../sdk.generated'
 
 export type ProposalVersion = Omit<
-  ProposalFragment,
-  'calldatas' | 'values' | 'proposer' | 'transactionHash' | 'updatePeriodEnd'
+  ProposalFragment | ProposalUpdatableFragment,
+  | 'calldatas'
+  | 'values'
+  | 'proposer'
+  | 'transactionHash'
+  | 'updatePeriodEnd'
+  | 'updateMessage'
+  | 'updateCount'
+  | 'candidateVersion'
+  | 'replaces'
+  | 'replacedBy'
 > & {
   proposer: string
   values: string[]
   calldatas: string[]
   transactionHash: string
-  updatePeriodEnd?: number
+  updatePeriodEnd?: number | null
+  updateMessage?: string | null
+  updateCount?: number | null
+  candidateVersion?: ProposalUpdatableFragment['candidateVersion'] | null
+  replaces?: ProposalUpdatableFragment['replaces'] | null
+  replacedBy?: ProposalUpdatableFragment['replacedBy'] | null
   state: ProposalState
 }
 
@@ -22,16 +37,24 @@ export const getProposalVersions = async (
   proposalNumber: number
 ): Promise<ProposalVersion[]> => {
   try {
-    const data = await SDK.connect(chainId).proposalVersions({
-      where: {
-        dao: daoAddress.toLowerCase(),
-        proposalNumber: proposalNumber,
-      },
-    })
+    const sdk = SDK.connect(chainId)
+    const data = supportsUpdatableProposals(chainId)
+      ? await sdk.proposalVersionsUpdatable({
+          where: {
+            dao: daoAddress.toLowerCase(),
+            proposalNumber: proposalNumber,
+          },
+        })
+      : await sdk.proposalVersions({
+          where: {
+            dao: daoAddress.toLowerCase(),
+            proposalNumber: proposalNumber,
+          },
+        })
 
     const versions = await Promise.all(
       data?.proposals.map(async (p) => {
-        const { calldatas, updatePeriodEnd, ...proposal } = p
+        const { calldatas, ...proposal } = p
 
         // Get state for each version
         const state = await getProposalState(
@@ -40,12 +63,23 @@ export const getProposalVersions = async (
           proposal.proposalId
         )
 
-        return {
+        const version: any = {
           ...proposal,
           calldatas: calldatas ? calldatas.split(':') : [],
-          updatePeriodEnd: updatePeriodEnd ? Number(updatePeriodEnd) : undefined,
           state,
         }
+
+        // Add updatable proposal fields (v0.1.17+) with explicit defaults (null, not undefined)
+        version.updatePeriodEnd =
+          'updatePeriodEnd' in p && p.updatePeriodEnd ? Number(p.updatePeriodEnd) : null
+        version.updateMessage = 'updateMessage' in p ? (p.updateMessage ?? null) : null
+        version.updateCount = 'updateCount' in p ? (p.updateCount ?? null) : null
+        version.candidateVersion =
+          'candidateVersion' in p ? (p.candidateVersion ?? null) : null
+        version.replaces = 'replaces' in p ? (p.replaces ?? null) : null
+        version.replacedBy = 'replacedBy' in p ? (p.replacedBy ?? null) : null
+
+        return version
       }) || []
     )
 

--- a/packages/sdk/src/subgraph/requests/proposalsQuery.ts
+++ b/packages/sdk/src/subgraph/requests/proposalsQuery.ts
@@ -1,3 +1,4 @@
+import { supportsUpdatableProposals } from '@buildeross/constants'
 import { CHAIN_ID } from '@buildeross/types'
 import { isProposalReplaced } from '@buildeross/utils/proposalState'
 
@@ -19,19 +20,28 @@ export const getProposals = async (
   page?: number
 ): Promise<ProposalsResponse> => {
   try {
-    const data = await SDK.connect(chainId).proposals({
-      where: {
-        dao: token.toLowerCase(),
-      },
-      first: limit,
-      skip: page ? (page - 1) * limit : 0,
-    })
+    const sdk = SDK.connect(chainId)
+    const data = supportsUpdatableProposals(chainId)
+      ? await sdk.proposalsUpdatable({
+          where: {
+            dao: token.toLowerCase(),
+          },
+          first: limit,
+          skip: page ? (page - 1) * limit : 0,
+        })
+      : await sdk.proposals({
+          where: {
+            dao: token.toLowerCase(),
+          },
+          first: limit,
+          skip: page ? (page - 1) * limit : 0,
+        })
 
     const allProposals = await Promise.all(
       data?.proposals.map(async (p) => {
-        const { executableFrom, expiresAt, calldatas, updatePeriodEnd, ...proposal } = p
+        const { executableFrom, expiresAt, calldatas, ...proposal } = p
 
-        const baseProposal = {
+        const baseProposal: any = {
           ...proposal,
           calldatas: calldatas ? calldatas.split(':') : [],
           state: await getProposalState(
@@ -39,8 +49,18 @@ export const getProposals = async (
             proposal.dao.governorAddress,
             proposal.proposalId
           ),
-          updatePeriodEnd: updatePeriodEnd ? Number(updatePeriodEnd) : undefined,
         }
+
+        // Add updatable proposal fields (v0.1.17+) with explicit defaults (null, not undefined)
+        baseProposal.updatePeriodEnd =
+          'updatePeriodEnd' in p && p.updatePeriodEnd ? Number(p.updatePeriodEnd) : null
+        baseProposal.updateMessage =
+          'updateMessage' in p ? (p.updateMessage ?? null) : null
+        baseProposal.updateCount = 'updateCount' in p ? (p.updateCount ?? null) : null
+        baseProposal.candidateVersion =
+          'candidateVersion' in p ? (p.candidateVersion ?? null) : null
+        baseProposal.replaces = 'replaces' in p ? (p.replaces ?? null) : null
+        baseProposal.replacedBy = 'replacedBy' in p ? (p.replacedBy ?? null) : null
 
         // executableFrom and expiresAt will always either be both defined, or neither defined
         if (executableFrom && expiresAt) {

--- a/packages/sdk/src/subgraph/sdk.generated.ts
+++ b/packages/sdk/src/subgraph/sdk.generated.ts
@@ -10959,26 +10959,7 @@ export type ProposalFragment = {
   executionTransactionHash?: any | null
   vetoTransactionHash?: any | null
   cancelTransactionHash?: any | null
-  updatePeriodEnd?: any | null
-  updateMessage?: string | null
-  updateCount: number
   dao: { __typename?: 'DAO'; governorAddress: any; tokenAddress: any }
-  candidateVersion?: {
-    __typename?: 'ProposalCandidateVersion'
-    candidateId: any
-    proposalHash: any
-    attestationUID: any
-    versionNumber: any
-    proposal?: {
-      __typename?: 'Proposal'
-      id: string
-      proposalId: any
-      proposalNumber: number
-    } | null
-    group: { __typename?: 'ProposalCandidateGroup'; candidateNumber: number }
-  } | null
-  replaces?: { __typename?: 'Proposal'; proposalId: any; proposalNumber: number } | null
-  replacedBy?: { __typename?: 'Proposal'; proposalId: any; proposalNumber: number } | null
 }
 
 export type ProposalDetailFragment = {
@@ -11011,10 +10992,42 @@ export type ProposalDetailFragment = {
   executionTransactionHash?: any | null
   vetoTransactionHash?: any | null
   cancelTransactionHash?: any | null
+  dao: { __typename?: 'DAO'; governorAddress: any; tokenAddress: any }
+}
+
+export type ProposalDetailUpdatableFragment = {
+  __typename?: 'Proposal'
+  metadata?: string | null
   updatePeriodEnd?: any | null
   updateMessage?: string | null
   updateCount: number
-  dao: { __typename?: 'DAO'; governorAddress: any; tokenAddress: any }
+  abstainVotes: number
+  againstVotes: number
+  calldatas?: string | null
+  description?: string | null
+  representedAddress?: string | null
+  discussionUrl?: string | null
+  descriptionHash: any
+  executableFrom?: any | null
+  expiresAt?: any | null
+  forVotes: number
+  proposalId: any
+  proposalNumber: number
+  proposalThreshold: any
+  proposer: any
+  quorumVotes: any
+  targets: Array<any>
+  timeCreated: any
+  title?: string | null
+  values: Array<any>
+  voteEnd: any
+  voteStart: any
+  snapshotBlockNumber: any
+  transactionHash: any
+  executedAt?: any | null
+  executionTransactionHash?: any | null
+  vetoTransactionHash?: any | null
+  cancelTransactionHash?: any | null
   candidateVersion?: {
     __typename?: 'ProposalCandidateVersion'
     candidateId: any
@@ -11031,6 +11044,58 @@ export type ProposalDetailFragment = {
   } | null
   replaces?: { __typename?: 'Proposal'; proposalId: any; proposalNumber: number } | null
   replacedBy?: { __typename?: 'Proposal'; proposalId: any; proposalNumber: number } | null
+  dao: { __typename?: 'DAO'; governorAddress: any; tokenAddress: any }
+}
+
+export type ProposalUpdatableFragment = {
+  __typename?: 'Proposal'
+  updatePeriodEnd?: any | null
+  updateMessage?: string | null
+  updateCount: number
+  abstainVotes: number
+  againstVotes: number
+  calldatas?: string | null
+  description?: string | null
+  representedAddress?: string | null
+  discussionUrl?: string | null
+  descriptionHash: any
+  executableFrom?: any | null
+  expiresAt?: any | null
+  forVotes: number
+  proposalId: any
+  proposalNumber: number
+  proposalThreshold: any
+  proposer: any
+  quorumVotes: any
+  targets: Array<any>
+  timeCreated: any
+  title?: string | null
+  values: Array<any>
+  voteEnd: any
+  voteStart: any
+  snapshotBlockNumber: any
+  transactionHash: any
+  executedAt?: any | null
+  executionTransactionHash?: any | null
+  vetoTransactionHash?: any | null
+  cancelTransactionHash?: any | null
+  candidateVersion?: {
+    __typename?: 'ProposalCandidateVersion'
+    candidateId: any
+    proposalHash: any
+    attestationUID: any
+    versionNumber: any
+    proposal?: {
+      __typename?: 'Proposal'
+      id: string
+      proposalId: any
+      proposalNumber: number
+    } | null
+    group: { __typename?: 'ProposalCandidateGroup'; candidateNumber: number }
+  } | null
+  replaces?: { __typename?: 'Proposal'; proposalId: any; proposalNumber: number } | null
+  replacedBy?: { __typename?: 'Proposal'; proposalId: any; proposalNumber: number } | null
+  dao: { __typename?: 'DAO'; governorAddress: any; tokenAddress: any }
 }
 
 export type ProposalVoteFragment = {
@@ -11039,7 +11104,7 @@ export type ProposalVoteFragment = {
   support: ProposalVoteSupport
   weight: number
   reason?: string | null
-  timestamp?: any
+  timestamp: any
 }
 
 export type SnapshotFragment = {
@@ -12272,11 +12337,74 @@ export type DaosForDashboardQuery = {
       executionTransactionHash?: any | null
       vetoTransactionHash?: any | null
       cancelTransactionHash?: any | null
+      votes: Array<{ __typename?: 'ProposalVote'; voter: any }>
+      dao: { __typename?: 'DAO'; governorAddress: any; tokenAddress: any }
+    }>
+    currentAuction?: {
+      __typename?: 'Auction'
+      endTime: any
+      highestBid?: { __typename?: 'AuctionBid'; amount: any; bidder: any } | null
+      token: { __typename?: 'Token'; name: string; image?: string | null; tokenId: any }
+    } | null
+    links: Array<{ __typename?: 'DAOLink'; id: string; key: string; url: string }>
+  }>
+}
+
+export type DaosForDashboardUpdatableQueryVariables = Exact<{
+  user: Scalars['Bytes']['input']
+  first?: InputMaybe<Scalars['Int']['input']>
+  skip?: InputMaybe<Scalars['Int']['input']>
+}>
+
+export type DaosForDashboardUpdatableQuery = {
+  __typename?: 'Query'
+  daos: Array<{
+    __typename?: 'DAO'
+    contractImage: string
+    name: string
+    tokenAddress: any
+    metadataAddress: any
+    treasuryAddress: any
+    auctionAddress: any
+    governorAddress: any
+    auctionConfig: {
+      __typename?: 'AuctionConfig'
+      minimumBidIncrement: any
+      reservePrice: any
+    }
+    proposals: Array<{
+      __typename?: 'Proposal'
+      voteEnd: any
+      voteStart: any
+      expiresAt?: any | null
       updatePeriodEnd?: any | null
       updateMessage?: string | null
       updateCount: number
+      abstainVotes: number
+      againstVotes: number
+      calldatas?: string | null
+      description?: string | null
+      representedAddress?: string | null
+      discussionUrl?: string | null
+      descriptionHash: any
+      executableFrom?: any | null
+      forVotes: number
+      proposalId: any
+      proposalNumber: number
+      proposalThreshold: any
+      proposer: any
+      quorumVotes: any
+      targets: Array<any>
+      timeCreated: any
+      title?: string | null
+      values: Array<any>
+      snapshotBlockNumber: any
+      transactionHash: any
+      executedAt?: any | null
+      executionTransactionHash?: any | null
+      vetoTransactionHash?: any | null
+      cancelTransactionHash?: any | null
       votes: Array<{ __typename?: 'ProposalVote'; voter: any }>
-      dao: { __typename?: 'DAO'; governorAddress: any; tokenAddress: any }
       candidateVersion?: {
         __typename?: 'ProposalCandidateVersion'
         candidateId: any
@@ -12301,6 +12429,7 @@ export type DaosForDashboardQuery = {
         proposalId: any
         proposalNumber: number
       } | null
+      dao: { __typename?: 'DAO'; governorAddress: any; tokenAddress: any }
     }>
     currentAuction?: {
       __typename?: 'Auction'
@@ -12939,38 +13068,15 @@ export type ProposalQuery = {
     executionTransactionHash?: any | null
     vetoTransactionHash?: any | null
     cancelTransactionHash?: any | null
-    updatePeriodEnd?: any | null
-    updateMessage?: string | null
-    updateCount: number
     votes: Array<{
       __typename?: 'ProposalVote'
       voter: any
       support: ProposalVoteSupport
       weight: number
       reason?: string | null
-      timestamp?: any
+      timestamp: any
     }>
     dao: { __typename?: 'DAO'; governorAddress: any; tokenAddress: any }
-    candidateVersion?: {
-      __typename?: 'ProposalCandidateVersion'
-      candidateId: any
-      proposalHash: any
-      attestationUID: any
-      versionNumber: any
-      proposal?: {
-        __typename?: 'Proposal'
-        id: string
-        proposalId: any
-        proposalNumber: number
-      } | null
-      group: { __typename?: 'ProposalCandidateGroup'; candidateNumber: number }
-    } | null
-    replaces?: { __typename?: 'Proposal'; proposalId: any; proposalNumber: number } | null
-    replacedBy?: {
-      __typename?: 'Proposal'
-      proposalId: any
-      proposalNumber: number
-    } | null
   } | null
 }
 
@@ -13027,16 +13133,74 @@ export type ProposalOgMetadataQuery = {
     executionTransactionHash?: any | null
     vetoTransactionHash?: any | null
     cancelTransactionHash?: any | null
-    updatePeriodEnd?: any | null
-    updateMessage?: string | null
-    updateCount: number
     votes: Array<{
       __typename?: 'ProposalVote'
       voter: any
       support: ProposalVoteSupport
       weight: number
       reason?: string | null
-      timestamp?: any
+      timestamp: any
+    }>
+    dao: {
+      __typename?: 'DAO'
+      name: string
+      contractImage: string
+      tokenAddress: any
+      metadataAddress: any
+      auctionAddress: any
+      treasuryAddress: any
+      governorAddress: any
+    }
+  }>
+}
+
+export type ProposalOgMetadataUpdatableQueryVariables = Exact<{
+  where: Proposal_Filter
+  first: Scalars['Int']['input']
+}>
+
+export type ProposalOgMetadataUpdatableQuery = {
+  __typename?: 'Query'
+  proposals: Array<{
+    __typename?: 'Proposal'
+    metadata?: string | null
+    updatePeriodEnd?: any | null
+    updateMessage?: string | null
+    updateCount: number
+    abstainVotes: number
+    againstVotes: number
+    calldatas?: string | null
+    description?: string | null
+    representedAddress?: string | null
+    discussionUrl?: string | null
+    descriptionHash: any
+    executableFrom?: any | null
+    expiresAt?: any | null
+    forVotes: number
+    proposalId: any
+    proposalNumber: number
+    proposalThreshold: any
+    proposer: any
+    quorumVotes: any
+    targets: Array<any>
+    timeCreated: any
+    title?: string | null
+    values: Array<any>
+    voteEnd: any
+    voteStart: any
+    snapshotBlockNumber: any
+    transactionHash: any
+    executedAt?: any | null
+    executionTransactionHash?: any | null
+    vetoTransactionHash?: any | null
+    cancelTransactionHash?: any | null
+    votes: Array<{
+      __typename?: 'ProposalVote'
+      voter: any
+      support: ProposalVoteSupport
+      weight: number
+      reason?: string | null
+      timestamp: any
     }>
     dao: {
       __typename?: 'DAO'
@@ -13069,6 +13233,77 @@ export type ProposalOgMetadataQuery = {
       proposalNumber: number
     } | null
   }>
+}
+
+export type ProposalUpdatableQueryVariables = Exact<{
+  proposalId: Scalars['ID']['input']
+}>
+
+export type ProposalUpdatableQuery = {
+  __typename?: 'Query'
+  proposal?: {
+    __typename?: 'Proposal'
+    metadata?: string | null
+    updatePeriodEnd?: any | null
+    updateMessage?: string | null
+    updateCount: number
+    abstainVotes: number
+    againstVotes: number
+    calldatas?: string | null
+    description?: string | null
+    representedAddress?: string | null
+    discussionUrl?: string | null
+    descriptionHash: any
+    executableFrom?: any | null
+    expiresAt?: any | null
+    forVotes: number
+    proposalId: any
+    proposalNumber: number
+    proposalThreshold: any
+    proposer: any
+    quorumVotes: any
+    targets: Array<any>
+    timeCreated: any
+    title?: string | null
+    values: Array<any>
+    voteEnd: any
+    voteStart: any
+    snapshotBlockNumber: any
+    transactionHash: any
+    executedAt?: any | null
+    executionTransactionHash?: any | null
+    vetoTransactionHash?: any | null
+    cancelTransactionHash?: any | null
+    votes: Array<{
+      __typename?: 'ProposalVote'
+      voter: any
+      support: ProposalVoteSupport
+      weight: number
+      reason?: string | null
+      timestamp: any
+    }>
+    candidateVersion?: {
+      __typename?: 'ProposalCandidateVersion'
+      candidateId: any
+      proposalHash: any
+      attestationUID: any
+      versionNumber: any
+      proposal?: {
+        __typename?: 'Proposal'
+        id: string
+        proposalId: any
+        proposalNumber: number
+      } | null
+      group: { __typename?: 'ProposalCandidateGroup'; candidateNumber: number }
+    } | null
+    replaces?: { __typename?: 'Proposal'; proposalId: any; proposalNumber: number } | null
+    replacedBy?: {
+      __typename?: 'Proposal'
+      proposalId: any
+      proposalNumber: number
+    } | null
+    dao: { __typename?: 'DAO'; governorAddress: any; tokenAddress: any }
+  } | null
 }
 
 export type ProposalVersionsQueryVariables = Exact<{
@@ -13106,10 +13341,48 @@ export type ProposalVersionsQuery = {
     executionTransactionHash?: any | null
     vetoTransactionHash?: any | null
     cancelTransactionHash?: any | null
+    dao: { __typename?: 'DAO'; governorAddress: any; tokenAddress: any }
+  }>
+}
+
+export type ProposalVersionsUpdatableQueryVariables = Exact<{
+  where?: InputMaybe<Proposal_Filter>
+}>
+
+export type ProposalVersionsUpdatableQuery = {
+  __typename?: 'Query'
+  proposals: Array<{
+    __typename?: 'Proposal'
     updatePeriodEnd?: any | null
     updateMessage?: string | null
     updateCount: number
-    dao: { __typename?: 'DAO'; governorAddress: any; tokenAddress: any }
+    abstainVotes: number
+    againstVotes: number
+    calldatas?: string | null
+    description?: string | null
+    representedAddress?: string | null
+    discussionUrl?: string | null
+    descriptionHash: any
+    executableFrom?: any | null
+    expiresAt?: any | null
+    forVotes: number
+    proposalId: any
+    proposalNumber: number
+    proposalThreshold: any
+    proposer: any
+    quorumVotes: any
+    targets: Array<any>
+    timeCreated: any
+    title?: string | null
+    values: Array<any>
+    voteEnd: any
+    voteStart: any
+    snapshotBlockNumber: any
+    transactionHash: any
+    executedAt?: any | null
+    executionTransactionHash?: any | null
+    vetoTransactionHash?: any | null
+    cancelTransactionHash?: any | null
     candidateVersion?: {
       __typename?: 'ProposalCandidateVersion'
       candidateId: any
@@ -13130,6 +13403,7 @@ export type ProposalVersionsQuery = {
       proposalId: any
       proposalNumber: number
     } | null
+    dao: { __typename?: 'DAO'; governorAddress: any; tokenAddress: any }
   }>
 }
 
@@ -13170,18 +13444,66 @@ export type ProposalsQuery = {
     executionTransactionHash?: any | null
     vetoTransactionHash?: any | null
     cancelTransactionHash?: any | null
-    updatePeriodEnd?: any | null
-    updateMessage?: string | null
-    updateCount: number
     votes: Array<{
       __typename?: 'ProposalVote'
       voter: any
       support: ProposalVoteSupport
       weight: number
       reason?: string | null
-      timestamp?: any
+      timestamp: any
     }>
     dao: { __typename?: 'DAO'; governorAddress: any; tokenAddress: any }
+  }>
+}
+
+export type ProposalsUpdatableQueryVariables = Exact<{
+  where?: InputMaybe<Proposal_Filter>
+  first: Scalars['Int']['input']
+  skip?: InputMaybe<Scalars['Int']['input']>
+}>
+
+export type ProposalsUpdatableQuery = {
+  __typename?: 'Query'
+  proposals: Array<{
+    __typename?: 'Proposal'
+    updatePeriodEnd?: any | null
+    updateMessage?: string | null
+    updateCount: number
+    abstainVotes: number
+    againstVotes: number
+    calldatas?: string | null
+    description?: string | null
+    representedAddress?: string | null
+    discussionUrl?: string | null
+    descriptionHash: any
+    executableFrom?: any | null
+    expiresAt?: any | null
+    forVotes: number
+    proposalId: any
+    proposalNumber: number
+    proposalThreshold: any
+    proposer: any
+    quorumVotes: any
+    targets: Array<any>
+    timeCreated: any
+    title?: string | null
+    values: Array<any>
+    voteEnd: any
+    voteStart: any
+    snapshotBlockNumber: any
+    transactionHash: any
+    executedAt?: any | null
+    executionTransactionHash?: any | null
+    vetoTransactionHash?: any | null
+    cancelTransactionHash?: any | null
+    votes: Array<{
+      __typename?: 'ProposalVote'
+      voter: any
+      support: ProposalVoteSupport
+      weight: number
+      reason?: string | null
+      timestamp: any
+    }>
     candidateVersion?: {
       __typename?: 'ProposalCandidateVersion'
       candidateId: any
@@ -13202,6 +13524,7 @@ export type ProposalsQuery = {
       proposalId: any
       proposalNumber: number
     } | null
+    dao: { __typename?: 'DAO'; governorAddress: any; tokenAddress: any }
   }>
 }
 
@@ -13381,7 +13704,7 @@ export type UserProposalVoteQuery = {
     support: ProposalVoteSupport
     weight: number
     reason?: string | null
-    timestamp?: any
+    timestamp: any
   }>
 }
 
@@ -13755,13 +14078,25 @@ export const ProposalFragmentDoc = gql`
     executionTransactionHash
     vetoTransactionHash
     cancelTransactionHash
-    updatePeriodEnd
-    updateMessage
-    updateCount
     dao {
       governorAddress
       tokenAddress
     }
+  }
+`
+export const ProposalDetailFragmentDoc = gql`
+  fragment ProposalDetail on Proposal {
+    ...Proposal
+    metadata
+  }
+  ${ProposalFragmentDoc}
+`
+export const ProposalUpdatableFragmentDoc = gql`
+  fragment ProposalUpdatable on Proposal {
+    ...Proposal
+    updatePeriodEnd
+    updateMessage
+    updateCount
     candidateVersion {
       candidateId
       proposalHash
@@ -13785,13 +14120,14 @@ export const ProposalFragmentDoc = gql`
       proposalNumber
     }
   }
+  ${ProposalFragmentDoc}
 `
-export const ProposalDetailFragmentDoc = gql`
-  fragment ProposalDetail on Proposal {
-    ...Proposal
+export const ProposalDetailUpdatableFragmentDoc = gql`
+  fragment ProposalDetailUpdatable on Proposal {
+    ...ProposalUpdatable
     metadata
   }
-  ${ProposalFragmentDoc}
+  ${ProposalUpdatableFragmentDoc}
 `
 export const ProposalVoteFragmentDoc = gql`
   fragment ProposalVote on ProposalVote {
@@ -14679,6 +15015,48 @@ export const DaosForDashboardDocument = gql`
   ${ProposalFragmentDoc}
   ${CurrentAuctionFragmentDoc}
 `
+export const DaosForDashboardUpdatableDocument = gql`
+  query daosForDashboardUpdatable($user: Bytes!, $first: Int, $skip: Int) {
+    daos(
+      where: { or: [{ voters_: { voter: $user } }, { owners_: { owner: $user } }] }
+      first: $first
+      skip: $skip
+    ) {
+      ...DAO
+      contractImage
+      auctionConfig {
+        minimumBidIncrement
+        reservePrice
+      }
+      proposals(
+        where: {
+          executed_not: true
+          canceled_not: true
+          vetoed_not: true
+          replacedBy: null
+        }
+        first: 10
+        skip: 0
+        orderBy: proposalNumber
+        orderDirection: desc
+      ) {
+        ...ProposalUpdatable
+        voteEnd
+        voteStart
+        expiresAt
+        votes {
+          voter
+        }
+      }
+      currentAuction {
+        ...CurrentAuction
+      }
+    }
+  }
+  ${DaoFragmentDoc}
+  ${ProposalUpdatableFragmentDoc}
+  ${CurrentAuctionFragmentDoc}
+`
 export const DaosForUserDocument = gql`
   query daosForUser($user: Bytes!, $first: Int, $skip: Int) {
     daos(
@@ -14978,13 +15356,54 @@ export const ProposalOgMetadataDocument = gql`
   ${ProposalDetailFragmentDoc}
   ${ProposalVoteFragmentDoc}
 `
+export const ProposalOgMetadataUpdatableDocument = gql`
+  query proposalOGMetadataUpdatable($where: Proposal_filter!, $first: Int!) {
+    proposals(where: $where, first: $first) {
+      ...ProposalDetailUpdatable
+      votes {
+        ...ProposalVote
+      }
+      dao {
+        name
+        contractImage
+        tokenAddress
+        metadataAddress
+        auctionAddress
+        treasuryAddress
+        governorAddress
+      }
+    }
+  }
+  ${ProposalDetailUpdatableFragmentDoc}
+  ${ProposalVoteFragmentDoc}
+`
+export const ProposalUpdatableDocument = gql`
+  query proposalUpdatable($proposalId: ID!) {
+    proposal(id: $proposalId) {
+      ...ProposalDetailUpdatable
+      votes {
+        ...ProposalVote
+      }
+    }
+  }
+  ${ProposalDetailUpdatableFragmentDoc}
+  ${ProposalVoteFragmentDoc}
+`
 export const ProposalVersionsDocument = gql`
   query proposalVersions($where: Proposal_filter) {
-    proposals(where: $where, orderBy: updateCount, orderDirection: asc) {
+    proposals(where: $where, orderBy: proposalNumber, orderDirection: asc) {
       ...Proposal
     }
   }
   ${ProposalFragmentDoc}
+`
+export const ProposalVersionsUpdatableDocument = gql`
+  query proposalVersionsUpdatable($where: Proposal_filter) {
+    proposals(where: $where, orderBy: updateCount, orderDirection: asc) {
+      ...ProposalUpdatable
+    }
+  }
+  ${ProposalUpdatableFragmentDoc}
 `
 export const ProposalsDocument = gql`
   query proposals($where: Proposal_filter, $first: Int!, $skip: Int) {
@@ -15002,6 +15421,24 @@ export const ProposalsDocument = gql`
     }
   }
   ${ProposalFragmentDoc}
+  ${ProposalVoteFragmentDoc}
+`
+export const ProposalsUpdatableDocument = gql`
+  query proposalsUpdatable($where: Proposal_filter, $first: Int!, $skip: Int) {
+    proposals(
+      where: $where
+      first: $first
+      skip: $skip
+      orderBy: timeCreated
+      orderDirection: desc
+    ) {
+      ...ProposalUpdatable
+      votes {
+        ...ProposalVote
+      }
+    }
+  }
+  ${ProposalUpdatableFragmentDoc}
   ${ProposalVoteFragmentDoc}
 `
 export const SnapshotsDocument = gql`
@@ -15735,6 +16172,24 @@ export function getSdk(
         variables
       )
     },
+    daosForDashboardUpdatable(
+      variables: DaosForDashboardUpdatableQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+      signal?: RequestInit['signal']
+    ): Promise<DaosForDashboardUpdatableQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<DaosForDashboardUpdatableQuery>({
+            document: DaosForDashboardUpdatableDocument,
+            variables,
+            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
+            signal,
+          }),
+        'daosForDashboardUpdatable',
+        'query',
+        variables
+      )
+    },
     daosForUser(
       variables: DaosForUserQueryVariables,
       requestHeaders?: GraphQLClientRequestHeaders,
@@ -15915,6 +16370,42 @@ export function getSdk(
         variables
       )
     },
+    proposalOGMetadataUpdatable(
+      variables: ProposalOgMetadataUpdatableQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+      signal?: RequestInit['signal']
+    ): Promise<ProposalOgMetadataUpdatableQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<ProposalOgMetadataUpdatableQuery>({
+            document: ProposalOgMetadataUpdatableDocument,
+            variables,
+            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
+            signal,
+          }),
+        'proposalOGMetadataUpdatable',
+        'query',
+        variables
+      )
+    },
+    proposalUpdatable(
+      variables: ProposalUpdatableQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+      signal?: RequestInit['signal']
+    ): Promise<ProposalUpdatableQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<ProposalUpdatableQuery>({
+            document: ProposalUpdatableDocument,
+            variables,
+            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
+            signal,
+          }),
+        'proposalUpdatable',
+        'query',
+        variables
+      )
+    },
     proposalVersions(
       variables?: ProposalVersionsQueryVariables,
       requestHeaders?: GraphQLClientRequestHeaders,
@@ -15933,6 +16424,24 @@ export function getSdk(
         variables
       )
     },
+    proposalVersionsUpdatable(
+      variables?: ProposalVersionsUpdatableQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+      signal?: RequestInit['signal']
+    ): Promise<ProposalVersionsUpdatableQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<ProposalVersionsUpdatableQuery>({
+            document: ProposalVersionsUpdatableDocument,
+            variables,
+            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
+            signal,
+          }),
+        'proposalVersionsUpdatable',
+        'query',
+        variables
+      )
+    },
     proposals(
       variables: ProposalsQueryVariables,
       requestHeaders?: GraphQLClientRequestHeaders,
@@ -15947,6 +16456,24 @@ export function getSdk(
             signal,
           }),
         'proposals',
+        'query',
+        variables
+      )
+    },
+    proposalsUpdatable(
+      variables: ProposalsUpdatableQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+      signal?: RequestInit['signal']
+    ): Promise<ProposalsUpdatableQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<ProposalsUpdatableQuery>({
+            document: ProposalsUpdatableDocument,
+            variables,
+            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
+            signal,
+          }),
+        'proposalsUpdatable',
         'query',
         variables
       )


### PR DESCRIPTION
note: this commit is intended to reverted once base subgraph syncs (within a week)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for updatable proposals on compatible networks, including updated proposal, version, and dashboard data.
  * Proposal pages now use network-appropriate metadata for supported chains.
  * Vote status now records and persists vote timestamps for more accurate display.
* **Bug Fixes**
  * Improved handling of replaced proposals to redirect safely using available replacement data.
  * Updated subgraph URL/version selection to avoid hardcoding a single subgraph version.
* **Tests**
  * Updated vote status tests to match the new timestamped vote payload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->