### PR TITLE
fix: guard updatable subgraph queries by schema support

### DIFF
--- a/packages/constants/src/subgraph.ts
+++ b/packages/constants/src/subgraph.ts
@@ -20,6 +20,16 @@ export const PUBLIC_SUBGRAPH_URL: Map<CHAIN_ID, string> = new Map([
   [CHAIN_ID.FOUNDRY, ''],
 ])
 
+const UPDATABLE_PROPOSALS_SUBGRAPH_CHAINS = PUBLIC_IS_TESTNET
+  ? new Set<CHAIN_ID>([
+      CHAIN_ID.ETHEREUM,
+      CHAIN_ID.OPTIMISM,
+      CHAIN_ID.SEPOLIA,
+      CHAIN_ID.OPTIMISM_SEPOLIA,
+      CHAIN_ID.BASE_SEPOLIA,
+    ])
+  : new Set<CHAIN_ID>()
+
 export const supportsUpdatableProposals = (chainId: CHAIN_ID): boolean => {
-  return chainId !== CHAIN_ID.BASE
+  return UPDATABLE_PROPOSALS_SUBGRAPH_CHAINS.has(chainId)
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected availability of updatable proposals across supported networks.
  * Updatable proposals are now enabled only on designated test networks and disabled on production networks, preventing unsupported proposal updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->